### PR TITLE
FullCalendar JS 사용한 초안 HTML 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 
     //Swagger-ui
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 }
 
 tasks.named('test') {

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang='ko'>
+<head>
+    <meta charset='utf-8'/>
+    <!-- Bootstrap 5 기본 스타일 -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet">
+
+    <!-- 1) 표준 FullCalendar 번들 (core + interaction + dayGrid + timeGrid + list + multimonth) -->
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.17/index.global.min.js"></script>
+    <!-- 2) Bootstrap5 테마 플러그인 -->
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/bootstrap5@6.1.17/index.global.min.js"></script>
+
+</head>
+
+<body>
+<!-- 1) 상단 네비게이션 바 -->
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">LeaveBridge</a> <!-- 홈으로 -->
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                data-bs-target="#navbarSupportedContent">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav mb-2 mb-lg-0">
+                <!-- 연차사용현황 버튼 -->
+                <li class="nav-item">
+                    <a class="nav-link" th:href="@{/usage}">연차사용현황</a>
+                </li>
+                <!-- 로그인(비인증 시) -->
+                <li class="nav-item" sec:authorize="!isAuthenticated()">
+                    <a class="nav-link" th:href="@{/login}">로그인</a>
+                </li>
+                <!-- 로그아웃(인증 시) -->
+                <li class="nav-item" sec:authorize="isAuthenticated()">
+                    <form th:action="@{/logout}" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-link nav-link p-0">
+                            로그아웃
+                        </button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div id='calendar'></div>
+<script>
+
+    document.addEventListener('DOMContentLoaded', function () {
+        let calendarEl = document.getElementById('calendar');
+        let calendar = new FullCalendar.Calendar(calendarEl, {
+            themeSystem: 'bootstrap5',
+            // 여러 속성들
+            initialView: 'dayGridMonth',  // 초기 보기 설정, 기본값 dayGridMonth
+            initialDate: getFormattedDate(),  // 캘린더 로드 시 초기 날짜 설절, 기본값 오늘 날짜
+            locale: 'ko',  // 언머 및 지역화 설정 변경
+            timeZone: 'Asia/Seoul', // IANA 시간대 설정(명명된 시간대)
+            weekends: true,  // 주말 포함 여부 기본값 true
+            height: '100%',   // 100%의 경우 부모 컨테이너 요소 높이와 일치
+            contentHeight: 'auto',  // 본문 영역 높이 auto시 뷰 높이 자연스럽고 스크롤바 사용 안함
+            aspectRatio: 1.5, // 너비: 높이 비율 1.5:1 (종횡비)
+            eventColor: '#3799d8',  // 기본 일정 배경색 서렂ㅇ (파란색)
+            eventTextColor: '#ffffff',  // 글자 색상 변경
+            dayMaxEvents: true,  // 하루 최대 이벤트 표시(true 인경우 적절히)
+            // moreLinkClick: function (info) {
+            //     alert('더보기 클릭: ' + info.data);
+            //     // 여기서 팝업을 열거나 다른 행동 정의할 수 있음
+            //     return false; // 기본 팝업 열림 방지(false: 팝업 열림, true: 팝업 안열림)
+            // },
+            selectable : true,   // 사용자가 선택하고 취소되는 시점 모니터링
+            headerToolbar: {
+                left: 'prev next',
+                center: 'title',
+                right: 'dayGridMonth timeGridWeek timeGridDay'
+            },
+            views: {
+                dayGridMonth: {
+                    titleFormat: {
+                        year: 'numeric',
+                        month: '2-digit'
+                    }
+                }
+            },
+            buttonText: {
+                today : '현재날짜',
+                month : '월',
+                week: '주',
+                day: '일'
+            },
+
+            // 일정 데이터 나타낼때(title, start, end, allDay 속성 포함 객체)
+            // 배열 마지막 이벤트 뒤 쉼표 없어야 함!(익스플로러 에러)
+            events: [
+                // 하루 일정
+                {
+                    id : 1,
+                    groupId : 1,
+                    title: '일정1',
+                    start: '2025-06-29',
+                    backgroundColor: '#ff0000', // 개별 일정 색상 설정 가능
+                    // end 속성은 종료일 지정하지 않는 경우 null
+                    // startStr, endStr 뭔지 모름
+                    // url : 사용자 이벤트 클릭 시 방문할 url (eventClick callback 참조)
+                    editable : true,  // 특정 이벤트에 대해 편집 가능 설정 재정의(일정바 선택 및 드래그)
+                    startEditable : true, // 특정 이벤트 드래그를 통해 이벤트 시작 시간 편집 허용
+                    ovarlap: false,  // 다른 이벤트가 해당 이벤트 위로 드래크/크기 조정 방지
+
+                },
+                // 기간 일정
+                {
+                    id : 2,
+                    groupId: 2,
+                    title: '일정2',
+                    start: '2025-06-29',
+                    end: '2025-06-30'
+                },
+                // 시간 포함 일정
+                {
+                    id: 2,
+                    title: '일정3',
+                    start: '2025-06-29T14:00:00',
+                    end: '2025-06-29T18:00:00',
+                    allDays: false  // true인 경우 시간 텍스트 함께 표시되지 않음
+                }
+            ],
+            // events : '/api/events'          // 서버에서 일정 JSON 데이터 로드
+            // event 클릭 함수 정의 -> 일정 정보 (수정, 삭제 가능하도록)
+            eventClick: function (info) {
+                alert('일정 제목: ' + info.event.title); // 제목 표시
+                // 일정 다시 불러오기 (서버)
+            },
+            // 날짜나 시간 클릭 시 발생 -> 일정 생성 폼 등록
+            dateClick: function (info) {
+                alert('클릭한 날짜: ' + info.dateStr); // 클릭한 날짜
+                // 일정 다시 불러오기(서버)
+            }
+
+        });
+        calendar.render();
+    });
+
+</script>
+
+<script>
+    /**
+     * 오늘 날짜를 'YYYY-MM-DD' 형식의 문자열로 반환합니다.
+     * @returns {string} 포맷된 날짜 문자열
+     */
+    function getFormattedDate() {
+        const today = new Date();   // 현재 날짜/시간을 담은 Date 객체 생성
+        const year = today.getFullYear();  // 4자리 연도 추출 (예: 2025)
+        const month = String(today.getMonth() + 1) // 월은 0~11로 반환하므로 +1 필요
+            .padStart(2, '0');                     // 한 자리일 때 앞에 '0' 추가
+        const day = String(today.getDate())    // 1~31 사이 일자 반환
+            .padStart(2, '0');                     // 한 자리일 때 앞에 '0' 추가
+
+        return `${year}-${month}-${day}`;  // 템플릿 리터럴로 최종 문자열 조합
+    }
+
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 구현 사항 요약
- 타임리프 의존성을 미리 추가했습니다.
  -  일정 불러오고 하는 것 사실상 Ajax 예상 되지만, 아마 로그인 / 로그아웃 화면 정도로만 사용하지 않을까 싶습니다.
- FullCalendar에서 사용할 이벤트 + 헤더 포함한 화면 구성 초안을 작성했습니다.
- 공식 문서 잘 정리한 블로그 글을 참조하며 옵션을 설정했습니다.
  - [FullCalendar 공식 문서 정리](https://junesker.tistory.com/108)

## 다음 구현 사항
- DB 도입
- Spring Security 도입
- CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
- 각각의 HTML 도입 및 수정
  - 일정 상세 페이지
  - 일정 수정 페이지
  - 메인 페이지 헤더
  - 페이지 사이징 반응형 등

