### PR TITLE
공휴일 조회 API제거, 공휴일 조회 API제거, 일정 조회 방법 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6' // 타임리프에서 시큐리티
+
+    // @retry 사용하기 위한 의존성 추가
+    implementation("org.springframework.retry:spring-retry")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leavebridge/LeaveBridgeApplication.java
+++ b/src/main/java/com/leavebridge/LeaveBridgeApplication.java
@@ -4,8 +4,12 @@ import java.util.TimeZone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
+@EnableRetry
 public class LeaveBridgeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -14,31 +14,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.google.api.services.calendar.model.Event;
+import com.leavebridge.calendar.dto.MonthlyEvent;
 import com.leavebridge.calendar.service.CalendarService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/api/calendar")
 @RequiredArgsConstructor
+@Slf4j
 public class CalendarController {
-	private final CalendarService calendarService;
 
-	/**
-	 * 공휴일 이벤트 조회
-	 */
-	@PostMapping("/holiday-events")
-	public ResponseEntity<String> getUpcomingHolidaysEvents() throws Exception {
-		calendarService.findHolidayFromGoogleCalendar();
-		return ResponseEntity.ok("공휴일 데이터가 성공적으로 저장되었습니다.");
-	}
+	private final CalendarService calendarService;
 
 	/**
 	 * 이번달 구글 캘린더 등록 이벤트 조회
 	 */
-	@GetMapping("/events")
-	public ResponseEntity<List<Event>> getUpcomingEvents() throws Exception {
-		List<Event> events = calendarService.listMonthlyEvents(2025, 6);
+	@GetMapping("/events/{year}/{month}")
+	public ResponseEntity<List<MonthlyEvent>> getUpcomingEvents(@PathVariable Integer year, @PathVariable Integer month) throws Exception {
+		log.info("getUpcomingEvents :: year={}, month={}", year, month);
+		List<MonthlyEvent> events = calendarService.listMonthlyEvents(year, month);
 		return ResponseEntity.ok(events);
 	}
 

--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
@@ -1,0 +1,37 @@
+package com.leavebridge.calendar.dto;
+
+import java.time.LocalDateTime;
+
+import com.leavebridge.calendar.entity.LeaveAndHoliday;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record MonthlyEvent(
+
+	@Schema(description = "DB상 일정 id", example = "2")
+	Long id,
+
+	@Schema(description = "일정 제목", example = "박철현 연차")
+	String title,
+
+	@Schema(description = "시작 시간", example = "'2025-06-29T14:00:00'")
+	LocalDateTime start,
+
+	@Schema(description = "종료 시간", example = "2025-06-29T18:00:00")
+	LocalDateTime end,
+
+	@Schema(description = "하루 종일 일정인지", example = "true or false")
+	boolean allDays
+) {
+	public static MonthlyEvent from(LeaveAndHoliday leaveAndHoliday) {
+		return MonthlyEvent.builder()
+			.id(leaveAndHoliday.getId())
+			.title(leaveAndHoliday.getTitle())
+			.start(leaveAndHoliday.getStartDate())
+			.end(leaveAndHoliday.getEndDate())
+			.allDays(leaveAndHoliday.getIsAllDay())
+			.build();
+	}
+}

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.google.api.services.calendar.model.Event;
@@ -36,7 +35,7 @@ public class LeaveAndHoliday {
 	private LocalDateTime endDate;
 
 	@Column(name = "IS_ALL_DAY")
-	private Boolean allDay;
+	private Boolean isAllDay;
 
 	// TODO : User 테이블 설계 후 변경
 	@Column(name = "USER_ID")
@@ -45,6 +44,9 @@ public class LeaveAndHoliday {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "LEAVE_TYPE", length = 50)
 	private LeaveType leaveType;
+
+	@Column(name = "GOOGLE_EVENT_ID")
+	private String googleEventId;
 
 	public static LeaveAndHoliday of (Event event, Long userId, LeaveType leaveType) {
 
@@ -56,9 +58,10 @@ public class LeaveAndHoliday {
 			.title(event.getSummary())
 			.startDate(start)
 			.endDate(end)
-			.allDay(isAllDay)
+			.isAllDay(isAllDay)
 			.userId(userId)
 			.leaveType(leaveType)
+			.googleEventId(event.getId())
 			.build();
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
+++ b/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
@@ -14,7 +14,9 @@ public enum LeaveType {
 
 	OUTING("외출"),
 
-	SUMMER_VACATION("여름휴가");
+	SUMMER_VACATION("여름휴가"),
+
+	OTHER_PEOPLE("비회원 연차");
 
 	private final String type;
 }

--- a/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
+++ b/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
@@ -1,18 +1,15 @@
 package com.leavebridge.calendar.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
-import com.leavebridge.calendar.enums.LeaveType;
 
 @Repository
 public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday, Long> {
-
-	/**
-	 * 주어진 leaveType에 대해 startDate가 year년 내에 하나라도 존재하는지 확인
-	 */
-	boolean existsByLeaveTypeAndStartDateBetween(LeaveType leaveType, LocalDateTime startOfYear, LocalDateTime endOfYear);
+	List<LeaveAndHoliday> findAllByGoogleEventIdIn(List<String> eventIds);
+	List<LeaveAndHoliday> findAllByStartDateGreaterThanEqualAndStartDateLessThan(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
+++ b/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
@@ -1,0 +1,131 @@
+package com.leavebridge.calendar.scheduler;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.Events;
+import com.leavebridge.calendar.entity.LeaveAndHoliday;
+import com.leavebridge.calendar.enums.LeaveType;
+import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class CalendarScheduler {
+
+	private final Calendar calendarClient;
+	private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
+	private final LeaveAndHolidayRepository leaveAndHolidayRepository;
+
+	@Value("${google.calendar-id}")
+	private String GOOGLE_PERSONAL_CALENDAR_ID;
+
+	private final static String GOOGLE_KOREA_HOLIDAY_CALENDAR_ID = "ko.south_korea#holiday@group.v.calendar.google.com";
+
+	// @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
+	@Scheduled(cron = "0 0 0 * * *")
+	@Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+	public void getLeaveSchduleRegularly() throws IOException {
+
+		LocalDate today = LocalDate.now();
+		int year = today.getYear();
+		int month = today.getMonthValue();
+
+		log.info("getLeaveSchduleRegularly {}", year + "-" + month);
+
+		// 월 시작: yyyy-MM-01T00:00:00Z
+		DateTime timeMin = new DateTime(String.format("%04d-%02d-01T00:00:00Z", year, month));
+
+		// 1) YearMonth로 말일(LocalDate) 구하기
+		YearMonth ym = YearMonth.of(year, month);
+		LocalDate lastDayDate = ym.atEndOfMonth();
+
+		// 2) 말일 자정(UTC)을 포함한 ISO 8601 문자열 생성
+		String timeMaxIso = String.format("%sT23:59:59Z", lastDayDate);
+
+		// 3) DateTime 객체로 변환
+		DateTime timeMax = new DateTime(timeMaxIso);
+
+		Events events = calendarClient.events().list(GOOGLE_PERSONAL_CALENDAR_ID)
+			.setTimeMin(timeMin)
+			.setTimeMax(timeMax)
+			.setSingleEvents(true)    // 반복 이벤트를 각 회차별로 개별 인스턴스로 분할해 반환
+			.setOrderBy("startTime")
+			.execute();
+
+		List<Event> items = events.getItems();
+
+		processAndSaveNewEvents(items, 0L, LeaveType.OTHER_PEOPLE);
+	}
+
+	// @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
+	@Scheduled(cron = "0 0 4 1 * *")
+	@Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+	public void getHolidaysRegularly() throws IOException {
+
+		log.info("getHolidaysRegularly :: {}", LocalDateTime.now());
+
+		Events holidaysEvents = calendarClient.events().list(GOOGLE_KOREA_HOLIDAY_CALENDAR_ID).execute();
+
+		List<Event> items = holidaysEvents.getItems();
+
+		processAndSaveNewEvents(items, 0L, LeaveType.HOLIDAY);
+	}
+
+	private void processAndSaveNewEvents(List<Event> events, Long userId, LeaveType type) {
+		if (events.isEmpty()) {
+			return;
+		}
+
+		// 1) 이벤트 ID 추출
+		List<String> eventIds = extractEventIds(events);
+
+		// 2) DB에 이미 있는 ID 조회
+		List<String> existingIds = findExistingEventIds(eventIds);
+
+		// 3) 신규 이벤트만 매핑 후 저장
+		List<LeaveAndHoliday> toSave = events.stream()
+			.filter(e -> !existingIds.contains(e.getId()))
+			.map(e -> LeaveAndHoliday.of(e, userId, type))
+			.sorted(Comparator.comparing(LeaveAndHoliday::getStartDate))
+			.toList();
+
+		leaveAndHolidayRepository.saveAll(toSave);
+	}
+
+	/**
+	 * 이벤트 리스트에서 Google Event ID만 추출
+	 */
+	private List<String> extractEventIds(List<Event> events) {
+		return events.stream()
+			.map(Event::getId)
+			.toList();
+	}
+
+	/**
+	 * DB에 이미 저장된 Google Event ID 목록 조회
+	 */
+	private List<String> findExistingEventIds(List<String> eventIds) {
+		return leaveAndHolidayRepository
+			.findAllByGoogleEventIdIn(eventIds)
+			.stream()
+			.map(LeaveAndHoliday::getGoogleEventId)
+			.toList();
+	}
+}

--- a/src/main/java/com/leavebridge/config/SecurityConfig.java
+++ b/src/main/java/com/leavebridge/config/SecurityConfig.java
@@ -3,15 +3,16 @@ package com.leavebridge.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)  // @PreAuthorize 사용하기 위해 필요
 public class SecurityConfig {
 
 	@Bean
@@ -28,7 +29,7 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.GET, "/").permitAll() // 메인 페이지 누구나 가능
 				// 예외 처리 로직 없을 때 Tomcat이 포워딩 하는 경로 접근 허용하여 예외 메세지 잘 전달되도록 허용
 				.requestMatchers("/error").permitAll()
-				.anyRequest().authenticated() // 나머지는 인증된 사용자만 가능
+				.anyRequest().permitAll() // 나머지는 인증된 사용자만 가능
 			)
 
 			.logout(

--- a/src/main/java/com/leavebridge/util/DateUtils.java
+++ b/src/main/java/com/leavebridge/util/DateUtils.java
@@ -2,7 +2,6 @@ package com.leavebridge.util;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 
 import com.google.api.services.calendar.model.Event;
@@ -24,17 +23,20 @@ public class DateUtils {
 		}
 		// 2) all-day 이벤트인 경우 date 필드만 채워짐
 		LocalDate date = LocalDate.parse(dt.getDate().toStringRfc3339());
-		// 시작이면 자정, 종료면 다음 날 자정(배타적 end) 또는 당일 23:59:59
+		// 시작이면 자정, 종료면 당일 23:59:59
 		return isStart
 			? date.atStartOfDay()
-			: date.atTime(LocalTime.MAX);
+			: date.atStartOfDay().minusNanos(1);  // all-day 이벤트의 경우 다음날 00:00:00 이기 때문에 1초 빼기
 	}
 
 	/**
 	 * 구글 캘린더 Event 객체를 통해 하루종일 이벤트인지 시간 정해진 이벤트인지 확인
 	 */
 	public static boolean determineAllDay(Event event) {
-		return event.getStart().getDateTime() == null;
+		// start.date 가 채워져 있으면 dateOnly:true 인 all-day 이벤트
+		//  EventDateTime.getDateTime()이 값이 있으면 시간 지정 이벤트 (all-day가 아님)
+		//   EventDateTime.getDate()이 값이 있으면 종일 이벤트 (all-day)
+		return event.getStart().getDate() != null;
 	}
 
 	/**


### PR DESCRIPTION
## 구현 사항 요약

- 공휴일 조회 API제거
  - 구글 캘린더 조회 방식 제거하고 DB에서 조회하도록 하기 위함
- 공휴일 DB 저장 스케줄러로 변경
  - 매달 1일 새벽 4시에 API 호출하여 DB에 없으면 저장하도록 수정
- 일정 조회 방법 변경
  - 구글 캘린더에 API 호출하여 일정 조회 -> DB에서 일정 조회하도록 변경
  - 일정 매일 00시에 구글 캘린더에서 일정 가져와서 저장하는 스케줄러 도입
    - Calendar Id가 DB에 없는 것이면 새로 저장하되, 실제로 서비스 이용 회원이 아니기 때문에 정보만 저장(캘린더 표기용)

## 목표 구현 사항
## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  - [ ] `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장
  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)
  - [ ] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [ ] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
  - [ ] 일정 수정
    - [ ] DB 수정
    - [ ] 구글 캘린더 수정
  - [ ] 일정 삭제
    - [ ] DB 삭제
    - [ ] 구글 캘린더 삭제 API 호출

- [ ] 개인별 연차 사용 현황 조회

- [ ] 각각의 HTML 도입 및 수정
  - 일정 상세 & 수정 페이지 모달
  - 메인 페이지 헤더
    - 비밀번호 변경
    - 연차 사용 현황
  - 페이지 반응형 등