### PR TITLE
일정 등록 / 수정 부분 리팩토링(구글 캘린더 -> DB 참조)

### DIFF
--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -53,9 +53,9 @@ public class CalendarController {
 	 * 일정 등록
 	 **/
 	@PostMapping("/events")
-	public ResponseEntity<Event> createHolidays() throws Exception {
-		Event event = calendarService.createTimedEvent("박철현 연차", LocalDateTime.now(), LocalDateTime.now());
-		return ResponseEntity.ok(event);
+	public ResponseEntity<Void> createHolidays(@RequestBody CreateLeaveRequestDto createLeaveRequestDto) throws Exception {
+		calendarService.createTimedEvent(createLeaveRequestDto);
+		return ResponseEntity.ok().build();
 	}
 
 	/**

--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -10,11 +10,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.google.api.services.calendar.model.Event;
+import com.leavebridge.calendar.dto.CreateLeaveRequestDto;
 import com.leavebridge.calendar.dto.MonthlyEvent;
+import com.leavebridge.calendar.dto.MonthlyEventDetailResponse;
 import com.leavebridge.calendar.service.CalendarService;
 
 import lombok.RequiredArgsConstructor;
@@ -42,9 +45,8 @@ public class CalendarController {
 	 * 특정 이벤트 상세 조회
 	 */
 	@GetMapping("/events/{eventId}")
-	public ResponseEntity<Event> getEventDetail(@PathVariable("eventId") String eventId) throws Exception {
-		Event events = calendarService.getEventDetails(eventId);
-		return ResponseEntity.ok(events);
+	public ResponseEntity<MonthlyEventDetailResponse> getEventDetail(@PathVariable("eventId") Long eventId){
+		return ResponseEntity.ok(calendarService.getEventDetails(eventId));
 	}
 
 	/**

--- a/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
@@ -1,0 +1,21 @@
+package com.leavebridge.calendar.dto;
+
+import java.time.LocalDateTime;
+
+import com.leavebridge.calendar.enums.LeaveType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateLeaveRequestDto(
+	@Schema(description = "일정 제목", example = "박철현 연차")
+	String title,
+	@Schema(description = "시작 시간", example = "2025-07-01T14:00:00")
+	LocalDateTime startDate,
+	@Schema(description = "종료 시간", example = "2025-07-01T14:00:00")
+	LocalDateTime endDate,
+	@Schema(description = "연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_LEAVE(반차),  OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차)")
+	LeaveType leaveType,
+	@Schema(description = "일정 상세 설명", example = "일정 설명 텍스트")
+	String description
+) {
+}

--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
@@ -14,9 +14,9 @@ public record MonthlyEventDetailResponse(
 	Long id,
 	@Schema(description = "일정 제목", example = "박철현 연차")
 	String title,
-	@Schema(description = "시작 시간", example = "2025-07-01T14:00:00Z")
+	@Schema(description = "시작 시간", example = "2025-07-01T14:00:00")
 	LocalDateTime startDate,
-	@Schema(description = "종료 시간", example = "2025-07-01T14:00:00Z")
+	@Schema(description = "종료 시간", example = "2025-07-01T14:00:00")
 	LocalDateTime endDate,
 	@Schema(description = "하루 종일 이벤트 여부", example = "true or false")
 	Boolean isAllDay,

--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
@@ -1,0 +1,40 @@
+package com.leavebridge.calendar.dto;
+
+import java.time.LocalDateTime;
+
+import com.leavebridge.calendar.entity.LeaveAndHoliday;
+import com.leavebridge.calendar.enums.LeaveType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record MonthlyEventDetailResponse(
+	@Schema(description = "Entity id", example = "1")
+	Long id,
+	@Schema(description = "일정 제목", example = "박철현 연차")
+	String title,
+	@Schema(description = "시작 시간", example = "2025-07-01T14:00:00Z")
+	LocalDateTime startDate,
+	@Schema(description = "종료 시간", example = "2025-07-01T14:00:00Z")
+	LocalDateTime endDate,
+	@Schema(description = "하루 종일 이벤트 여부", example = "true or false")
+	Boolean isAllDay,
+	@Schema(description = "연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_LEAVE(반차),  OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차)")
+	LeaveType leaveType,
+	@Schema(description = "일정 상세 설명", example = "일정 설명 텍스트")
+	String description
+
+) {
+	public static MonthlyEventDetailResponse from(LeaveAndHoliday leaveAndHoliday) {
+		return MonthlyEventDetailResponse.builder()
+			.id(leaveAndHoliday.getId())
+			.title(leaveAndHoliday.getTitle())
+			.startDate(leaveAndHoliday.getStartDate())
+			.endDate(leaveAndHoliday.getEndDate())
+			.isAllDay(leaveAndHoliday.getIsAllDay())
+			.leaveType(leaveAndHoliday.getLeaveType())
+			.description(leaveAndHoliday.getDescription())
+			.build();
+	}
+}

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 import com.google.api.services.calendar.model.Event;
+import com.leavebridge.calendar.dto.CreateLeaveRequestDto;
 import com.leavebridge.calendar.enums.LeaveType;
 import com.leavebridge.util.DateUtils;
 
@@ -66,6 +67,22 @@ public class LeaveAndHoliday {
 			.leaveType(leaveType)
 			.googleEventId(event.getId())
 			.description(event.getDescription())
+			.build();
+	}
+
+	public static LeaveAndHoliday of(CreateLeaveRequestDto requestDto, long userId, String googleCalendarId) {
+
+		boolean isAllDay = DateUtils.determineAllDayByCreateLeaveRequestDto(requestDto);
+
+		return LeaveAndHoliday.builder()
+			.title(requestDto.title())
+			.startDate(requestDto.startDate())
+			.endDate(requestDto.endDate())
+			.isAllDay(isAllDay)
+			.userId(userId)
+			.leaveType(requestDto.leaveType())
+			.googleEventId(googleCalendarId)
+			.description(requestDto.description())
 			.build();
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -48,6 +48,9 @@ public class LeaveAndHoliday {
 	@Column(name = "GOOGLE_EVENT_ID")
 	private String googleEventId;
 
+	@Column(name = "DESCRIPTION")
+	private String description;
+
 	public static LeaveAndHoliday of (Event event, Long userId, LeaveType leaveType) {
 
 		LocalDateTime start = DateUtils.parseDateTime(event.getStart(), true);
@@ -62,6 +65,7 @@ public class LeaveAndHoliday {
 			.userId(userId)
 			.leaveType(leaveType)
 			.googleEventId(event.getId())
+			.description(event.getDescription())
 			.build();
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -16,6 +16,7 @@ import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
 import com.leavebridge.calendar.dto.MonthlyEvent;
+import com.leavebridge.calendar.dto.MonthlyEventDetailResponse;
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
 import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
 
@@ -35,24 +36,15 @@ public class CalendarService {
 	@Value("${google.calendar-id}")
 	private String GOOGLE_PERSONAL_CALENDAR_ID;
 
-
 	/**
 	 * 특정 이벤트의 상세 정보를 조회합니다.
 	 */
-	public Event getEventDetails(String eventId) throws IOException {
-		try {
-			return calendarClient.events()
-				.get(GOOGLE_PERSONAL_CALENDAR_ID, eventId)
-				.execute();
-		} catch (GoogleJsonResponseException e) {
-			// 404 Not Found 처리
-			if (e.getStatusCode() == 404) {
-				log.warn("이벤트를 찾을 수 없습니다. eventId={}", eventId);
-				return null;
-			}
-			// 그 외 오류는 다시 던집니다.
-			throw new RuntimeException(e.getMessage());
-		}
+	public MonthlyEventDetailResponse getEventDetails(Long eventId) {
+
+		LeaveAndHoliday leaveAndHoliday = leaveAndHolidayRepository.findById(eventId).orElseThrow(
+			() -> new IllegalArgumentException("존재하지 않는 일정 Id입니다."));
+
+		return MonthlyEventDetailResponse.from(leaveAndHoliday);
 	}
 
 	/**

--- a/src/main/java/com/leavebridge/config/SecurityConfig.java
+++ b/src/main/java/com/leavebridge/config/SecurityConfig.java
@@ -24,14 +24,14 @@ public class SecurityConfig {
 	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
-				.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-				.requestMatchers(HttpMethod.POST, "/api/*/member/login").permitAll() // 로그인은 누구나 가능
-				.requestMatchers(HttpMethod.GET, "/").permitAll() // 메인 페이지 누구나 가능
-				// 예외 처리 로직 없을 때 Tomcat이 포워딩 하는 경로 접근 허용하여 예외 메세지 잘 전달되도록 허용
+				// .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+				// .requestMatchers(HttpMethod.POST, "/api/*/member/login").permitAll() // 로그인은 누구나 가능
+				// .requestMatchers(HttpMethod.GET, "/").permitAll() // 메인 페이지 누구나 가능
+				// // 예외 처리 로직 없을 때 Tomcat이 포워딩 하는 경로 접근 허용하여 예외 메세지 잘 전달되도록 허용
 				.requestMatchers("/error").permitAll()
 				.anyRequest().permitAll() // 나머지는 인증된 사용자만 가능
 			)
-
+			.csrf(csrf -> csrf.disable())
 			.logout(
 				logout -> logout
 					.logoutSuccessUrl("/")

--- a/src/main/java/com/leavebridge/util/DateUtils.java
+++ b/src/main/java/com/leavebridge/util/DateUtils.java
@@ -6,6 +6,8 @@ import java.time.ZoneId;
 
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
+import com.leavebridge.calendar.dto.CreateLeaveRequestDto;
+import com.leavebridge.calendar.enums.LeaveType;
 
 public class DateUtils {
 
@@ -47,5 +49,28 @@ public class DateUtils {
 			java.time.Instant.ofEpochMilli(millis),
 			ZoneId.of("Asia/Seoul")
 		);
+	}
+
+	public static boolean determineAllDayByCreateLeaveRequestDto(CreateLeaveRequestDto requestDto) {
+		LeaveType type = requestDto.leaveType();
+
+		// 1) FULL_DAY_LEAVE, SUMMER_VACATION, HOLIDAY 는 모두 종일(all-day)
+		if (type == LeaveType.FULL_DAY_LEAVE
+			|| type == LeaveType.SUMMER_VACATION
+			|| type == LeaveType.HOLIDAY) {
+			return true;
+		}
+
+		// 2) 시작·종료가 같은 날이고 8 ~ 17시로 정확한 경우도 true
+		LocalDateTime start = requestDto.startDate();
+		LocalDateTime end = requestDto.endDate();
+		if (start.toLocalDate().equals(end.toLocalDate())) {
+			if (start.getHour() == 8 && end.getHour() >= 17) {
+				return true;
+			}
+		}
+
+		// 그 외는 all-day 아님
+		return false;
 	}
 }


### PR DESCRIPTION
## 구현 사항 요약
- 일정 등록 구글 캘린더 저장 이후에 DB 저장하도록 수정
  - 추후 예외 처리 + 연차 타입에 따른 시작, 종료 시간 검증 로직 필요
- 일정 상세 조회 구글 캘린더가 아닌 DB에서 조회하도록 수정

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  - [ ] `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요

  - [ ] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
    - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정

  - [ ] 일정 수정
    - [ ] DB 수정
    - [ ] 구글 캘린더 수정
    - [ ] Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] 일정 삭제
    - [ ] DB 삭제
    - [ ] 구글 캘린더 삭제 API 호출
    - [ ] Calendar 일정 다시 DB에서 받아오고 갱신

- [ ] 개인별 연차 사용 현황 조회

- [ ] 각각의 HTML 도입 및 수정
  - 일정 상세 & 수정 페이지 모달
  - 메인 페이지 헤더
    - 비밀번호 변경
    - 연차 사용 현황
  - 페이지 반응형 등