### PR TITLE
일정 수정, 삭제 로직 변경

### DIFF
--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -1,7 +1,6 @@
 package com.leavebridge.calendar.controller;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -14,10 +13,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.google.api.services.calendar.model.Event;
 import com.leavebridge.calendar.dto.CreateLeaveRequestDto;
 import com.leavebridge.calendar.dto.MonthlyEvent;
 import com.leavebridge.calendar.dto.MonthlyEventDetailResponse;
+import com.leavebridge.calendar.dto.PatchLeaveRequestDto;
 import com.leavebridge.calendar.service.CalendarService;
 
 import lombok.RequiredArgsConstructor;
@@ -62,8 +61,8 @@ public class CalendarController {
 	 * 특정 이벤트 수정
 	 */
 	@PatchMapping("/events/{eventId}")
-	public ResponseEntity<Void> updateHolidays(@PathVariable("eventId") String eventId) throws IOException {
-		calendarService.updateEventDate(eventId, LocalDateTime.now(), LocalDateTime.now());
+	public ResponseEntity<Void> updateHolidays(@PathVariable("eventId") Long eventId, @RequestBody PatchLeaveRequestDto patchLeaveRequestDto) throws IOException {
+		calendarService.updateEventDate(eventId, patchLeaveRequestDto);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -70,7 +70,7 @@ public class CalendarController {
 	 * 특정 이벤트 삭제
 	 */
 	@DeleteMapping("/events/{eventId}")
-	public ResponseEntity<Void> deleteHolidays(@PathVariable("eventId") String eventId) throws IOException {
+	public ResponseEntity<Void> deleteHolidays(@PathVariable("eventId") Long eventId) throws IOException {
 		calendarService.deleteEvent(eventId);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
@@ -1,0 +1,23 @@
+package com.leavebridge.calendar.dto;
+
+import java.time.LocalDateTime;
+
+import com.leavebridge.calendar.enums.LeaveType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record PatchLeaveRequestDto(
+	@Schema(description = "수정 일정 제목", example = "박철현 연차")
+	String title,
+	@Schema(description = "수정 시작 시간", example = "2025-07-01T14:00:00")
+	LocalDateTime startDate,
+	@Schema(description = "수정 종료 시간", example = "2025-07-01T14:00:00")
+	LocalDateTime endDate,
+	@Schema(description = "수정 연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_LEAVE(반차),  OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차)")
+	LeaveType leaveType,
+	@Schema(description = "수정 일정 상세 설명", example = "일정 설명 텍스트")
+	String description
+) {
+}

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -1,17 +1,25 @@
 package com.leavebridge.calendar.entity;
 
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 
 import com.google.api.services.calendar.model.Event;
 import com.leavebridge.calendar.dto.CreateLeaveRequestDto;
+import com.leavebridge.calendar.dto.PatchLeaveRequestDto;
 import com.leavebridge.calendar.enums.LeaveType;
 import com.leavebridge.util.DateUtils;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -52,11 +60,11 @@ public class LeaveAndHoliday {
 	@Column(name = "DESCRIPTION")
 	private String description;
 
-	public static LeaveAndHoliday of (Event event, Long userId, LeaveType leaveType) {
+	public static LeaveAndHoliday of(Event event, Long userId, LeaveType leaveType) {
 
 		LocalDateTime start = DateUtils.parseDateTime(event.getStart(), true);
-		LocalDateTime end   = DateUtils.parseDateTime(event.getEnd(), false);
-		boolean isAllDay     = DateUtils.determineAllDay(event);
+		LocalDateTime end = DateUtils.parseDateTime(event.getEnd(), false);
+		boolean isAllDay = DateUtils.determineAllDay(event);
 
 		return LeaveAndHoliday.builder()
 			.title(event.getSummary())
@@ -72,7 +80,7 @@ public class LeaveAndHoliday {
 
 	public static LeaveAndHoliday of(CreateLeaveRequestDto requestDto, long userId, String googleCalendarId) {
 
-		boolean isAllDay = DateUtils.determineAllDayByCreateLeaveRequestDto(requestDto);
+		boolean isAllDay = DateUtils.determineAllDay(requestDto);
 
 		return LeaveAndHoliday.builder()
 			.title(requestDto.title())
@@ -84,5 +92,25 @@ public class LeaveAndHoliday {
 			.googleEventId(googleCalendarId)
 			.description(requestDto.description())
 			.build();
+	}
+
+	public void patchEntityByDto(PatchLeaveRequestDto dto) {
+		if (dto.title() != null) {
+			this.title = dto.title();
+		}
+		if (dto.startDate() != null) {
+			this.startDate = dto.startDate();
+		}
+		if (dto.endDate() != null) {
+			this.endDate = dto.endDate();
+		}
+		if (dto.leaveType() != null) {
+			this.leaveType = dto.leaveType();
+		}
+		if (dto.description() != null) {
+			this.description = dto.description();
+		}
+		boolean isAllDay = DateUtils.determineAllDay(dto);
+		this.isAllDay = isAllDay;
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.util.DateTime;
@@ -163,7 +164,7 @@ public class CalendarService {
 		boolean changed = false;
 
 		// --- 1) summary(제목) 검사/적용 ---
-		if (dto.title() != null) {
+		if (StringUtils.hasText(dto.title())) {
 			String curTitle = apiEvent.getSummary();
 			if (!dto.title().equals(curTitle)) {
 				apiEvent.setSummary(dto.title());
@@ -172,7 +173,7 @@ public class CalendarService {
 		}
 
 		// --- 2) description(설명) 검사/적용 ---
-		if (dto.description() != null) {
+		if (StringUtils.hasText(dto.description())) {
 			String curDesc = apiEvent.getDescription();
 			if (!dto.description().equals(curDesc)) {
 				apiEvent.setDescription(dto.description());


### PR DESCRIPTION
## 구현 사항 요약
- 일정 수정 로직 변경(구글 캘린더에서 기존꺼와 변경사항 하나라도 있는 경우만 API 호출)
  - 구글 캘린더 바로 수정 -> DB 수정 + 구글 캘린더 수정 방식
- 일정 삭제 로직 변경
  - 구글 캘린더 바로 삭제 -> DB 삭제 + 구글 캘린더 삭제 방식

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  - [ ] `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요

  - [ ] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리

  - [ ] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [ ] Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [ ] Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] API 리팩토링
    - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
    - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
    - [ ] Query DSL 도입하여 Dto로 응답 바로 받을 수 있는것들 처리 등

- [ ] 개인별 연차 사용 현황 조회

- [ ] 각각의 HTML 도입 및 수정
  - 일정 상세 & 수정 페이지 모달
  - 메인 페이지 헤더
    - 비밀번호 변경
    - 연차 사용 현황
  - 페이지 반응형 등