### PR TITLE
달력 월별 API 호출, 일정 상세 모달 도입

### DIFF
--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
@@ -23,7 +23,7 @@ public record MonthlyEvent(
 	LocalDateTime end,
 
 	@Schema(description = "하루 종일 일정인지", example = "true or false")
-	boolean allDays
+	boolean allDay
 ) {
 	public static MonthlyEvent from(LeaveAndHoliday leaveAndHoliday) {
 		return MonthlyEvent.builder()
@@ -31,7 +31,7 @@ public record MonthlyEvent(
 			.title(leaveAndHoliday.getTitle())
 			.start(leaveAndHoliday.getStartDate())
 			.end(leaveAndHoliday.getEndDate())
-			.allDays(leaveAndHoliday.getIsAllDay())
+			.allDay(leaveAndHoliday.getIsAllDay())
 			.build();
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,3 +6,5 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+  thymeleaf:
+    cache: false   # 템플릿 캐싱 비활성화 (개발 환경에서만)

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -19,15 +19,94 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
     <!-- 1) 표준 FullCalendar 번들 (core + interaction + dayGrid + timeGrid + list + multimonth) -->
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.17/index.global.min.js"></script>
     <!-- 2) Bootstrap5 테마 플러그인 -->
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/bootstrap5@6.1.17/index.global.min.js"></script>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+
+
 </head>
 
 <body>
+
+<!-- 이벤트 상세 모달 -->
+<div id="eventDetailModal" class="modal fade" tabindex="-1" aria-labelledby="eventDetailLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 id="modalTitle" class="modal-title">
+                    <i class="bi bi-calendar-event me-2"></i>
+                    이벤트 제목
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="닫기"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="col-12">
+                        <dl class="row">
+                            <dt class="col-sm-3">
+                                <i class="bi bi-clock me-1"></i>시작 시간
+                            </dt>
+                            <dd id="modalStart" class="col-sm-9">2025-07-10T10:00:00</dd>
+
+                            <dt class="col-sm-3">
+                                <i class="bi bi-clock-history me-1"></i>종료 시간
+                            </dt>
+                            <dd id="modalEnd" class="col-sm-9">2025-07-10T12:00:00</dd>
+
+                            <dt class="col-sm-3">
+                                <i class="bi bi-card-text me-1"></i>설명
+                            </dt>
+                            <dd id="modalDescription" class="col-sm-9">세부 일정 및 준비물</dd>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <div class="btn-group-custom d-flex">
+                    <button id="modalEditBtn" type="button" class="btn btn-outline-primary">
+                        <i class="bi bi-pencil me-1"></i>수정
+                    </button>
+                    <button id="modalDeleteBtn" type="button" class="btn btn-outline-danger">
+                        <i class="bi bi-trash me-1"></i>삭제
+                    </button>
+                </div>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                    <i class="bi bi-x-circle me-1"></i>닫기
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 삭제 확인 모달 -->
+<div id="deleteConfirmModal" class="modal fade" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header bg-danger text-white">
+                <h5 class="modal-title" id="deleteConfirmLabel">
+                    <i class="bi bi-exclamation-triangle me-2"></i>삭제 확인
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="닫기"></button>
+            </div>
+            <div class="modal-body">
+                <p>정말로 이 일정을 삭제하시겠습니까?</p>
+                <p class="text-muted">삭제된 일정은 복구할 수 없습니다.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                <button id="confirmDeleteBtn" type="button" class="btn btn-danger">삭제</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
 <!-- 1) 상단 네비게이션 바 -->
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="container-fluid">
@@ -53,9 +132,10 @@
         </div>
     </div>
 </nav>
-<div id='calendar'></div>
-<script>
 
+<div id='calendar'></div>
+
+<script>
     document.addEventListener('DOMContentLoaded', function () {
         let calendarEl = document.getElementById('calendar');
         let calendar = new FullCalendar.Calendar(calendarEl, {
@@ -70,7 +150,7 @@
             height: '100%',   // 100%의 경우 부모 컨테이너 요소 높이와 일치
             contentHeight: 'auto',  // 본문 영역 높이 auto시 뷰 높이 자연스럽고 스크롤바 사용 안함
             aspectRatio: 1.5, // 너비: 높이 비율 1.5:1 (종횡비)
-            eventColor: '#3799d8',  // 기본 일정 배경색 서렂ㅇ (파란색)
+            eventColor: '#3799d8',  // 기본 일정 배경색 설정 (파란색)
             eventTextColor: '#ffffff',  // 글자 색상 변경
             dayMaxEvents: true,  // 하루 최대 이벤트 표시(true 인경우 적절히)
             // moreLinkClick: function (info) {
@@ -99,48 +179,53 @@
                 day: '일'
             },
 
-            // 일정 데이터 나타낼때(title, start, end, allDay 속성 포함 객체)
-            // 배열 마지막 이벤트 뒤 쉼표 없어야 함!(익스플로러 에러)
-            events: [
-                // 하루 일정
-                {
-                    id : 1,
-                    groupId : 1,
-                    title: '일정1',
-                    start: '2025-06-29',
-                    backgroundColor: '#ff0000', // 개별 일정 색상 설정 가능
-                    // end 속성은 종료일 지정하지 않는 경우 null
-                    // startStr, endStr 뭔지 모름
-                    // url : 사용자 이벤트 클릭 시 방문할 url (eventClick callback 참조)
-                    editable : true,  // 특정 이벤트에 대해 편집 가능 설정 재정의(일정바 선택 및 드래그)
-                    startEditable : true, // 특정 이벤트 드래그를 통해 이벤트 시작 시간 편집 허용
-                    ovarlap: false,  // 다른 이벤트가 해당 이벤트 위로 드래크/크기 조정 방지
-
-                },
-                // 기간 일정
-                {
-                    id : 2,
-                    groupId: 2,
-                    title: '일정2',
-                    start: '2025-06-20',
-                    end: '2025-06-30'
-                },
-                // 시간 포함 일정
-                {
-                    id: 2,
-                    title: '일정3',
-                    start: '2025-06-29T14:00:00',
-                    end: '2025-06-29T18:00:00',
-                    allDays: false  // true인 경우 시간 텍스트 함께 표시되지 않음
-                }
-            ],
             // 서버에서 일정 JSON 데이터 로드
-            // events : '/api/events'
+            events: (info) => {
+                // info.start는 Date 객체이므로, getTime()으로 밀리초를 얻고
+                // 10일 = 10 * 24 * 60 * 60 * 1000 밀리초를 더합니다.
+                const tenDaysMs = 10 * 24 * 60 * 60 * 1000;
+                const midDate   = new Date(info.start.getTime() + tenDaysMs);
+
+                const y = midDate.getFullYear();      // 예: 2025
+                const m = midDate.getMonth() + 1;     // 1~12
+
+                // GET 요청 → Promise 반환
+                return fetch(`/api/v1/calendar/events/${y}/${m}`)
+                    .then(res => {
+                        if (!res.ok) throw new Error('네트워크 에러');
+                        return res.json();                // JSON 배열을 반환하는 Promise
+                    });
+            },
 
             // event 클릭 함수 정의 -> 일정 정보 (수정, 삭제 가능하도록)
             eventClick: function (info) {
-                alert('일정 제목: ' + info.event.title); // 제목 표시
-                // 일정 다시 불러오기 (서버)
+                // 클릭된 이벤트의 ID 추출
+                const eventId = info.event.id;
+
+                // 서버에서 상세 정보 불러오기
+                fetch(`/api/v1/calendar/events/${eventId}`)
+                    .then(response => {
+                        if (!response.ok) throw new Error('네트워크 응답 실패');
+                        return response.json();
+                    })
+                    .then(data => {
+                        // 모달 내부 요소에 데이터 채우기
+                        document.getElementById('modalTitle').textContent       = data.title;
+                        document.getElementById('modalStart').textContent       = data.startDate;
+                        document.getElementById('modalEnd').textContent         = data.endDate;
+                        document.getElementById('modalDescription').textContent = data.description || '설명 없음';
+
+                        // 수정 버튼에 링크 설정 (원하면)
+                        document.getElementById('modalEditBtn').href = `/events/edit/${eventId}`;
+
+                        // Bootstrap 모달 표시
+                        const modal = new bootstrap.Modal(document.getElementById('eventDetailModal'));
+                        modal.show();
+                    })
+                    .catch(err => {
+                        console.error('이벤트 상세 조회 중 오류:', err);
+                        alert('이벤트 정보를 불러오는 데 실패했습니다.');
+                    });
             },
 
             // 날짜나 시간 클릭 시 발생 -> 일정 생성 폼 등록
@@ -154,6 +239,7 @@
     });
 
 </script>
+
 
 <script>
     /**


### PR DESCRIPTION
## 구현 사항 요약
- 달력 월 변경 시 해당 월의 이벤트 조회해서 보여지도록 수정
- 일정 상세 모달 도입

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  ~~- `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)~~
  - **테이블 없이 조회할 때마다 추출하도록 임시 구현**
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [ ] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [ ] 프론트에서 API 호출
      - [ ]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [ ] 프론트 API 호출
      - [ ]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [ ] 프론트 API 호출
      - [ ] Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] API 리팩토링
    - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
    - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
    - [ ] Query DSL 도입하여 Dto로 응답 바로 받을 수 있는것들 처리 등

- [x] 개인별 연차 사용 현황 조회
  - 테이블 설계 없이 기능 구현

- [ ] 각각의 HTML 도입 및 수정
  - 일정 상세 & 수정 페이지 모달
  - 메인 페이지 헤더
    - 비밀번호 변경
    - 연차 사용 현황
  - 페이지 반응형 등