### PR TITLE
일정 등록 프론트 + Spring 코드 수정

### DIFF
--- a/src/main/java/com/leavebridge/LeaveBridgeApplication.java
+++ b/src/main/java/com/leavebridge/LeaveBridgeApplication.java
@@ -4,12 +4,14 @@ import java.util.TimeZone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
 @EnableRetry
+@EnableJpaAuditing
 public class LeaveBridgeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -34,7 +34,8 @@ public class CalendarController {
 	 * 이번달 구글 캘린더 등록 이벤트 조회
 	 */
 	@GetMapping("/events/{year}/{month}")
-	public ResponseEntity<List<MonthlyEvent>> getUpcomingEvents(@PathVariable Integer year, @PathVariable Integer month) throws Exception {
+	public ResponseEntity<List<MonthlyEvent>> getUpcomingEvents(@PathVariable Integer year,
+		@PathVariable Integer month) throws Exception {
 		log.info("getUpcomingEvents :: year={}, month={}", year, month);
 		List<MonthlyEvent> events = calendarService.listMonthlyEvents(year, month);
 		return ResponseEntity.ok(events);
@@ -44,7 +45,7 @@ public class CalendarController {
 	 * 특정 이벤트 상세 조회
 	 */
 	@GetMapping("/events/{eventId}")
-	public ResponseEntity<MonthlyEventDetailResponse> getEventDetail(@PathVariable("eventId") Long eventId){
+	public ResponseEntity<MonthlyEventDetailResponse> getEventDetail(@PathVariable("eventId") Long eventId) {
 		return ResponseEntity.ok(calendarService.getEventDetails(eventId));
 	}
 
@@ -52,7 +53,8 @@ public class CalendarController {
 	 * 일정 등록
 	 **/
 	@PostMapping("/events")
-	public ResponseEntity<Void> createHolidays(@RequestBody CreateLeaveRequestDto createLeaveRequestDto) throws Exception {
+	public ResponseEntity<Void> createHolidays(@RequestBody CreateLeaveRequestDto createLeaveRequestDto) throws
+		Exception {
 		calendarService.createTimedEvent(createLeaveRequestDto);
 		return ResponseEntity.ok().build();
 	}
@@ -61,7 +63,8 @@ public class CalendarController {
 	 * 특정 이벤트 수정
 	 */
 	@PatchMapping("/events/{eventId}")
-	public ResponseEntity<Void> updateHolidays(@PathVariable("eventId") Long eventId, @RequestBody PatchLeaveRequestDto patchLeaveRequestDto) throws IOException {
+	public ResponseEntity<Void> updateHolidays(@PathVariable("eventId") Long eventId,
+		@RequestBody PatchLeaveRequestDto patchLeaveRequestDto) throws IOException {
 		calendarService.updateEventDate(eventId, patchLeaveRequestDto);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
@@ -1,6 +1,7 @@
 package com.leavebridge.calendar.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 import com.leavebridge.calendar.enums.LeaveType;
 
@@ -9,13 +10,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CreateLeaveRequestDto(
 	@Schema(description = "일정 제목", example = "박철현 연차")
 	String title,
-	@Schema(description = "시작 시간", example = "2025-07-01T14:00:00")
-	LocalDateTime startDate,
-	@Schema(description = "종료 시간", example = "2025-07-01T14:00:00")
-	LocalDateTime endDate,
-	@Schema(description = "연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_LEAVE(반차),  OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차)")
+	@Schema(description = "하루 종일 일정 여부", example = "true")
+	Boolean isAllDay,
+	@Schema(description = "연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_MORNING(오전_반차), HALF_DAY_AFTERNOON(오후 반차), OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차), NON_DEDUCTIBLE(공결, 병가, 기타 미소진 연차), MEETING(회의)")
 	LeaveType leaveType,
-	@Schema(description = "일정 상세 설명", example = "일정 설명 텍스트")
+	@Schema(description = "시작 날짜", example = "2025-07-01")
+	LocalDate startDate,
+	@Schema(description = "종료 날짜", example = "2025-07-01")
+	LocalDate endDate,
+	@Schema(description = "시작 날짜 시간", example = "00:00")
+	LocalTime startTime,
+	@Schema(description = "종료 날짜 시간", example = "23:59")
+	LocalTime endTime,
+
+	@Schema(description = "비고", example = "일정 설명 텍스트")
 	String description
 ) {
 }

--- a/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
+++ b/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
@@ -6,19 +6,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum LeaveType {
-	HOLIDAY("공휴일"),
+	HOLIDAY("공휴일", false),
 
-	FULL_DAY_LEAVE("1일 연차"),
+	FULL_DAY_LEAVE("1일 연차", true),
 
-	HALF_DAY_LEAVE("반차"),
+	HALF_DAY_MORNING ("오전 반차", true),
 
-	OUTING("외출"),
+	HALF_DAY_AFTERNOON("오후 반차", true),
 
-	SUMMER_VACATION("여름휴가"),
+	OUTING("외출", true),
 
-	OTHER_PEOPLE("비회원 연차");
+	SUMMER_VACATION("여름휴가", true),
 
-	// TODO : 회의, 병결, 공가 등 추가하여 연차 소진 안되게
+	OTHER_PEOPLE("비회원 연차", false),
+
+	NON_DEDUCTIBLE("비차감 휴가", false),  // 공결, 병가, 기타 소진 안될 휴가
+
+	MEETING("회의", false),;
 
 	private final String type;
+	private final boolean isDeductible;  // true면 연차 소진
 }

--- a/src/main/java/com/leavebridge/member/service/MemberService.java
+++ b/src/main/java/com/leavebridge/member/service/MemberService.java
@@ -86,16 +86,15 @@ public class MemberService {
 	/**
 	 * LeaveAndHoliday → 사용 “일수” 환산 (하루 단위 분할)
 	 */
-	private double calcUsedDays(LeaveAndHoliday l) {
+	private double calcUsedDays(LeaveAndHoliday leaveAndHoliday) {
 
-		// 공휴일이면 차감 0
-		// TODO : 회의, 병결, 공가 등 추가하여 연차 소진 안되게 타입 지정 가능
-		if (l.getLeaveType() == LeaveType.HOLIDAY) {
+		// 연차 소진 안될 일정이면 사용 시간 0 -> 공휴일, 회의, 공가 등
+		if (!leaveAndHoliday.getLeaveType().isDeductible()) {
 			return 0.0;
 		}
 
-		LocalDateTime start = l.getStartDate();
-		LocalDateTime end = l.getEndDate();
+		LocalDateTime start = leaveAndHoliday.getStartDate();
+		LocalDateTime end = leaveAndHoliday.getEndDate();
 
 		double totalMinutes = 0;
 

--- a/src/main/java/com/leavebridge/util/DateUtils.java
+++ b/src/main/java/com/leavebridge/util/DateUtils.java
@@ -2,7 +2,9 @@ package com.leavebridge.util;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.Objects;
 
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
@@ -53,10 +55,27 @@ public class DateUtils {
 	}
 
 	/**
+	 * 주어진 날짜와 시간으로 LocalDateTime 생성.
+	 * @param date 날짜 (null 이면 null 반환)
+	 * @param time 시간 (null 이면 date.atStartOfDay() 사용)
+	 */
+	public static LocalDateTime makeLocalDateTimeFromLocalDAteAndLocalTime(LocalDate date, LocalTime time) {
+		if (Objects.isNull(date)) {
+			return null;
+		}
+		return Objects.isNull(time)
+			? date.atStartOfDay()
+			: LocalDateTime.of(date, time);
+	}
+
+	/**
 	 * Create DTO 전용 래퍼
 	 */
 	public static boolean determineAllDay(CreateLeaveRequestDto dto) {
-		return isAllDay(dto.leaveType(), dto.startDate(), dto.endDate());
+		LocalDateTime starDateTime = DateUtils.makeLocalDateTimeFromLocalDAteAndLocalTime(dto.startDate(), dto.startTime());
+		LocalDateTime endDateTime = DateUtils.makeLocalDateTimeFromLocalDAteAndLocalTime(dto.endDate(), dto.endTime());
+
+		return isAllDay(dto.leaveType(), starDateTime, endDateTime);
 	}
 
 	/**

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -13,25 +13,128 @@
         html * {
             font-family: 'Pretendard-Regular', sans-serif;
         }
+
+        /* 날짜 숫자를 가로·세로 중앙 정렬 */
+        .fc .fc-daygrid-day-top {
+            display: flex;
+            justify-content: center; /* 가로 중앙 정렬 */
+            align-items: center;     /* 세로 중앙 정렬 */
+        }
+
+        /* daygrid 뷰의 날짜 셀 hover 시 배경색 변경 */
+        .fc .fc-daygrid-day:hover {
+            background-color: #f0f8ff;
+            cursor: pointer;
+        }
+
     </style>
     <meta charset='utf-8'/>
     <!-- Bootstrap 5 기본 스타일 -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
     <!-- 1) 표준 FullCalendar 번들 (core + interaction + dayGrid + timeGrid + list + multimonth) -->
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.17/index.global.min.js"></script>
     <!-- 2) Bootstrap5 테마 플러그인 -->
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/bootstrap5@6.1.17/index.global.min.js"></script>
-
+    <!-- 부트스트랩 모달까지 사용하기 위함 -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
 
+    <script>
+        // 현재 페이지의 호스트를 뽑아서 livereload.js를 로드
+        (function () {
+            var host = window.location.hostname || 'localhost';
+            var script = document.createElement('script');
+            script.src = 'http://' + host + ':35729/livereload.js?snipver=1';
+            document.head.appendChild(script);
+        })();
+    </script>
 
 </head>
 
 <body>
+
+<!-- 일정 입력/수정 모달 -->
+<div id="eventFormModal" class="modal fade" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <form id="eventForm" class="modal-content">
+            <div class="modal-header">
+                <h5 id="formModalTitle" class="modal-title">일정 등록</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label for="inputTitle" class="form-label">일정 제목</label>
+                    <input type="text" class="form-control" id="inputTitle" name="title" placeholder="박철현 연차" required>
+                </div>
+
+                <!-- 숨겨진 필드로 false 기본값 지정 -->
+                <input type="hidden" name="allDay" value="false">
+                <!-- 종일 체크박스 -->
+                <div class="form-check mb-3">
+                    <input class="form-check-input" type="checkbox" value="true" id="allDayCheck" name="isAllDay"
+                           checked>
+                    <label class="form-check-label" for="allDayCheck">
+                        하루 종일 여부(All Day)
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label for="leaveType" class="form-label">휴가 유형</label>
+                    <select id="leaveType" name="leaveType" class="form-select" required>
+                        <option value="">-- 유형 선택 --</option>
+                        <option value="FULL_DAY_LEAVE">연차</option>
+                        <option value="HALF_DAY_MORNING">오전 반차</option>
+                        <option value="HALF_DAY_AFTERNOON">오후 반차</option>
+                        <option value="OUTING">외출(시간지정 연차)</option>
+                        <option value="SUMMER_VACATION">여름휴가</option>
+                        <option value="NON_DEDUCTIBLE">비차감 휴가(공가)</option>
+                        <option value="MEETING">회의</option>
+                    </select>
+                    <div class="form-text text-muted">
+                        한 번에 하나의 연차 타입만 등록 가능합니다. 다른 타입은 별도 등록해 주세요.
+                    </div>
+                </div>
+
+                <!-- 날짜 입력(항상 보임) -->
+                <div class="row mb-3">
+                    <div class="col">
+                        <label for="inputStartDate" class="form-label">시작 날짜</label>
+                        <input type="date" class="form-control" id="inputStartDate" name="startDate" required>
+                    </div>
+                    <div class="col">
+                        <label for="inputEndDate" class="form-label">종료 날짜</label>
+                        <input type="date" class="form-control" id="inputEndDate" name="endDate" required>
+                    </div>
+                </div>
+
+                <!-- 시간 입력(체크박스에 따라 토글) -->
+                <div class="row mb-3" id="timeGroup" style="display: none;">
+                    <div class="col">
+                        <label for="inputStartTime" class="form-label">시작 시간</label>
+                        <input type="time" class="form-control" id="inputStartTime" name="startTime" value="00:00">
+                    </div>
+                    <div class="col">
+                        <label for="inputEndTime" class="form-label">종료 시간</label>
+                        <input type="time" class="form-control" id="inputEndTime" name="endTime" value="23:59">
+                    </div>
+                </div>
+                <!-- 비고 -->
+                <div class="mb-3">
+                    <label for="inputDescription" class="form-label">비고</label>
+                    <textarea class="form-control" id="inputDescription" name="description" rows="3"
+                              placeholder="공결 사유 등 입력(꼭 필요한 경우만 - 개인 연차 사용 미입력)"></textarea>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <!-- <button> 요소에 type 속성을 명시하지 않으면 HTML5 기준에서 type="submit"이 디폴트 적용 -->
+                <button type="submit" class="btn btn-primary" id="submitBtn">일정 등록</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">등록 취소</button>
+            </div>
+        </form>
+    </div>
+</div>
 
 <!-- 이벤트 상세 모달 -->
 <div id="eventDetailModal" class="modal fade" tabindex="-1" aria-labelledby="eventDetailLabel" aria-hidden="true">
@@ -42,7 +145,8 @@
                     <i class="bi bi-calendar-event me-2"></i>
                     이벤트 제목
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="닫기"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+                        aria-label="닫기"></button>
             </div>
             <div class="modal-body">
                 <div class="row">
@@ -84,14 +188,16 @@
 </div>
 
 <!-- 삭제 확인 모달 -->
-<div id="deleteConfirmModal" class="modal fade" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
+<div id="deleteConfirmModal" class="modal fade" tabindex="-1" aria-labelledby="deleteConfirmLabel"
+     aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title" id="deleteConfirmLabel">
                     <i class="bi bi-exclamation-triangle me-2"></i>삭제 확인
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="닫기"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+                        aria-label="닫기"></button>
             </div>
             <div class="modal-body">
                 <p>정말로 이 일정을 삭제하시겠습니까?</p>
@@ -104,7 +210,6 @@
         </div>
     </div>
 </div>
-
 
 
 <!-- 1) 상단 네비게이션 바 -->
@@ -136,14 +241,167 @@
 <div id='calendar'></div>
 
 <script>
-    document.addEventListener('DOMContentLoaded', function () {
-        let calendarEl = document.getElementById('calendar');
+
+    // Vanilla JS로 CSRF 메타 태그를 꺼내되, 없으면 빈 문자열('')
+    const header = document
+            .querySelector("meta[name='_csrf_header']")
+            ?.getAttribute("content")
+        ?? "";
+
+    const token = document
+            .querySelector("meta[name='_csrf']")
+            ?.getAttribute("content")
+        ?? "";
+
+    /**
+     * 오늘 날짜를 'YYYY-MM-DD' 형식의 문자열로 반환합니다.
+     * @returns {string} 포맷된 날짜 문자열
+     */
+    function getFormattedDate() {
+        const today = new Date();   // 현재 날짜/시간을 담은 Date 객체 생성
+        const year = today.getFullYear();  // 4자리 연도 추출 (예: 2025)
+        const month = String(today.getMonth() + 1) // 월은 0~11로 반환하므로 +1 필요
+            .padStart(2, '0');                     // 한 자리일 때 앞에 '0' 추가
+        const day = String(today.getDate())    // 1~31 사이 일자 반환
+            .padStart(2, '0');                     // 한 자리일 때 앞에 '0' 추가
+
+        return `${year}-${month}-${day}`;  // 템플릿 리터럴로 최종 문자열 조합
+    }
+
+    /*
+        좀 더 친숙한 시간 표현대로 변경하는 함수
+     */
+    function formatKoreanDateTime(isoString) {
+        const date = new Date(isoString);
+        const formatter = new Intl.DateTimeFormat('ko-KR', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            hour12: true
+        });
+        // 예: "2025년 7월 10일 오후 2:00"
+        return formatter.format(date);
+    }
+
+    function onModifyToggleAllDayChange() {
+        const allDayCheck = document.getElementById('allDayCheck');
+        const timeGroup = document.getElementById('timeGroup');
+        const startTime = document.getElementById('inputStartTime');
+        const endTime = document.getElementById('inputEndTime');
+        if (allDayCheck.checked) {
+            // 종일: 시간 입력 숨기기
+            timeGroup.style.display = 'none';
+            startTime.required = false;
+            endTime.required = false;
+        } else {
+            // 시간 지정: 시간 입력 보이기
+            timeGroup.style.display = '';
+            startTime.required = true;
+            endTime.required = true;
+        }
+    }
+
+    allDayCheck.addEventListener('change', onModifyToggleAllDayChange);
+
+    document.addEventListener('DOMContentLoaded', () => {
+        // 1) 요소 조회
+        const leaveTypeEl = document.getElementById('leaveType');
+        const allDayCheck = document.getElementById('allDayCheck');
+        const timeGroup = document.getElementById('timeGroup');
+        const startTimeEl = document.getElementById('inputStartTime');
+        const endTimeEl = document.getElementById('inputEndTime');
+        const descriptionEl = document.getElementById('inputDescription');
+        const formModal = new bootstrap.Modal(document.getElementById('eventFormModal'));
+        const calendarEl = document.getElementById('calendar');
+        const submitBtn = document.getElementById('submitBtn');
+
+        allDayCheck.addEventListener('change', onModifyToggleAllDayChange);
+
+        // 3) leaveType 변경 시 UI 조정
+        function onLeaveTypeChange() {
+            const currentType = leaveTypeEl.value;
+
+            // 0) 유형이 기본값(빈 문자열)일 때
+            if (currentType === "") {
+                // 종일 체크박스 활성화 / 체크 가능
+                allDayCheck.disabled = false;
+                allDayCheck.checked  = true;
+                // 시간 그룹 숨기기
+                timeGroup.style.display = 'none';
+                startTimeEl.required = false;
+                endTimeEl.required   = false;
+                // 비고 필수 해제
+                descriptionEl.required = false;
+                return;  // 여기서 끝내고 switch 문은 타지 않음
+            }
+
+            // 기본 리셋
+            allDayCheck.disabled = false;
+            allDayCheck.checked = true;
+            timeGroup.style.display = 'none';
+            startTimeEl.readOnly = false;
+            endTimeEl.readOnly = false;
+            startTimeEl.removeAttribute('min');
+            startTimeEl.removeAttribute('max');
+            endTimeEl.removeAttribute('min');
+            endTimeEl.removeAttribute('max');
+            descriptionEl.required = false;
+
+            switch (currentType) {
+                case 'FULL_DAY_LEAVE':
+                case 'SUMMER_VACATION':
+                    allDayCheck.checked = true;
+                    allDayCheck.disabled = true;
+                    startTimeEl.value = '00:00';
+                    endTimeEl.value   = '23:59';
+                    break;
+                case 'HALF_DAY_MORNING':
+                    allDayCheck.checked = false;
+                    allDayCheck.disabled = true;
+                    timeGroup.style.display = '';
+                    startTimeEl.value = '08:00';
+                    endTimeEl.value = '13:00';
+                    startTimeEl.readOnly = true;
+                    endTimeEl.readOnly = true;
+                    break;
+                case 'HALF_DAY_AFTERNOON':
+                    allDayCheck.checked = false;
+                    allDayCheck.disabled = true;
+                    timeGroup.style.display = '';
+                    startTimeEl.value = '13:00';
+                    endTimeEl.value = '17:00';
+                    startTimeEl.readOnly = true;
+                    endTimeEl.readOnly = true;
+                    break;
+                case 'OUTING':
+                    allDayCheck.checked = false;
+                    allDayCheck.disabled = true;
+                    timeGroup.style.display = '';
+                    startTimeEl.min = '08:00';
+                    startTimeEl.max = '17:00';
+                    endTimeEl.min = '08:00';
+                    endTimeEl.max = '17:00';
+                    break;
+                case 'NON_DEDUCTIBLE':
+                case 'MEETING':
+                    descriptionEl.required = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        leaveTypeEl.addEventListener('change', onLeaveTypeChange);
+
+        // 4) FullCalendar 초기화
         let calendar = new FullCalendar.Calendar(calendarEl, {
             themeSystem: 'bootstrap5',
             // 여러 속성들
             initialView: 'dayGridMonth',  // 초기 보기 설정, 기본값 dayGridMonth
             initialDate: getFormattedDate(),  // 캘린더 로드 시 초기 날짜 설절, 기본값 오늘 날짜
-            displayEventEnd: true,    // 종료 시간도 함께 표시
+            // displayEventEnd: true,    // 종료 시간도 함께 표시
             locale: 'ko',  // 언머 및 지역화 설정 변경
             timeZone: 'Asia/Seoul', // IANA 시간대 설정(명명된 시간대)
             weekends: true,  // 주말 포함 여부 기본값 true
@@ -158,7 +416,7 @@
             //     // 여기서 팝업을 열거나 다른 행동 정의할 수 있음
             //     return false; // 기본 팝업 열림 방지(false: 팝업 열림, true: 팝업 안열림)
             // },
-            selectable : true,   // 사용자가 선택하고 취소되는 시점 모니터링
+            selectable: true,   // 사용자가 선택하고 취소되는 시점 모니터링
             headerToolbar: {
                 left: 'prev next',
                 center: 'title',
@@ -173,18 +431,18 @@
                 }
             },
             buttonText: {
-                today : '현재날짜',
-                month : '월',
+                today: '현재날짜',
+                month: '월',
                 week: '주',
                 day: '일'
             },
 
             // 서버에서 일정 JSON 데이터 로드
             events: (info) => {
-                // info.start는 Date 객체이므로, getTime()으로 밀리초를 얻고
-                // 10일 = 10 * 24 * 60 * 60 * 1000 밀리초를 더합니다.
-                const tenDaysMs = 10 * 24 * 60 * 60 * 1000;
-                const midDate   = new Date(info.start.getTime() + tenDaysMs);
+                // info.start : 화면에 표시된 달력 첫날
+                // 달력의 첫날은 매월 1일이 보장 안되기에(이전달의 30일 일수도) 10일정도 더해서 월 맞추기 위함
+                const tenDaysMs = 10 * 24 * 60 * 60 * 1000;  // 10일
+                const midDate = new Date(info.start.getTime() + tenDaysMs);
 
                 const y = midDate.getFullYear();      // 예: 2025
                 const m = midDate.getMonth() + 1;     // 1~12
@@ -210,9 +468,9 @@
                     })
                     .then(data => {
                         // 모달 내부 요소에 데이터 채우기
-                        document.getElementById('modalTitle').textContent       = data.title;
-                        document.getElementById('modalStart').textContent       = data.startDate;
-                        document.getElementById('modalEnd').textContent         = data.endDate;
+                        document.getElementById('modalTitle').textContent = data.title;
+                        document.getElementById('modalStart').textContent = formatKoreanDateTime(data.startDate);
+                        document.getElementById('modalEnd').textContent = formatKoreanDateTime(data.endDate);
                         document.getElementById('modalDescription').textContent = data.description || '설명 없음';
 
                         // 수정 버튼에 링크 설정 (원하면)
@@ -230,34 +488,92 @@
 
             // 날짜나 시간 클릭 시 발생 -> 일정 생성 폼 등록
             dateClick: function (info) {
-                alert('클릭한 날짜: ' + info.dateStr); // 클릭한 날짜
-                // 일정 다시 불러오기(서버)
+                // 1) 모달 제목 설정 (등록 모드)
+                document.getElementById('formModalTitle').textContent = '일정 등록';
+                // 2) 폼 리셋 & 일정 등록 버튼 활성화
+                document.getElementById('eventForm').reset();
+                submitBtn.disabled = false
+                // 3) “종일” 체크 & 토글
+                const allDayCheck = document.getElementById('allDayCheck');
+                allDayCheck.checked = true;        // 종일 모드로 강제 전환
+
+                // 4) 날짜 입력값을 클릭한 날짜로 초기화
+                document.getElementById('inputStartDate').value = info.dateStr;
+                document.getElementById('inputEndDate').value = info.dateStr;
+
+                // 5) 모달 띄우기
+                formModal.show();
             }
 
         });
         calendar.render();
+        window.calendar = calendar;
+
+        // 5) 페이지 로드 직후에도 선택값 반영
+        onLeaveTypeChange();
+
+
+        // 1) Bootstrap 5 모달 닫기
+        function closeEventFormModal() {
+            formModal.hide();
+        }
+
+        // 2) FullCalendar 이벤트 다시 불러오기
+        function refreshCalendarEvents() {
+            calendar.refetchEvents();
+        }
+
+
+        // 폼 제출 이벤트 잡기 - form 태그 안에 button 있으면 제출
+        const eventForm = document.getElementById('eventForm');
+        eventForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const formData = new FormData(eventForm);
+            const dataObj = Object.fromEntries(formData.entries());
+
+            // 2) 등록 버튼 비활성화
+            submitBtn.disabled = true;
+
+            // 1) 기본 헤더
+            const fetchHeaders = {
+                'Content-Type': 'application/json'
+            };
+
+            // 2) CSRF 헤더가 유효하면 추가
+            if (header && token) {
+                fetchHeaders[header] = token;
+            }
+
+            fetch('/api/v1/calendar/events', {
+                method: 'POST',
+                headers: fetchHeaders,
+                body: JSON.stringify(dataObj)
+            })
+                .then(res => {
+                    if (!res.ok) throw new Error('서버 오류');
+                    // 204나 빈 바디일 때는 JSON 파싱 건너뛰기
+                    if (res.status === 204 || res.headers.get('Content-Length') === '0') {
+                        return null;
+                    }
+                    return res.json();
+                })
+                .then(() => {
+                    // ② 등록 성공: 모달 닫고, 캘린더 이벤트 새로 불러오기
+                    closeEventFormModal();      // 모달 닫기
+                    refreshCalendarEvents();    // 캘린더 갱신
+                })
+                .catch(err => {
+                    // ③ 실패: 토스트 띄우기
+                    console.error(err);
+                    // 3) 실패 → 버튼 재활성화
+                    submitBtn.disabled = false;
+                    alert('등록에 실패했습니다. 다시 시도해 주세요.');
+                });
+        });
+
     });
 
 </script>
 
-
-<script>
-    /**
-     * 오늘 날짜를 'YYYY-MM-DD' 형식의 문자열로 반환합니다.
-     * @returns {string} 포맷된 날짜 문자열
-     */
-    function getFormattedDate() {
-        const today = new Date();   // 현재 날짜/시간을 담은 Date 객체 생성
-        const year = today.getFullYear();  // 4자리 연도 추출 (예: 2025)
-        const month = String(today.getMonth() + 1) // 월은 0~11로 반환하므로 +1 필요
-            .padStart(2, '0');                     // 한 자리일 때 앞에 '0' 추가
-        const day = String(today.getDate())    // 1~31 사이 일자 반환
-            .padStart(2, '0');                     // 한 자리일 때 앞에 '0' 추가
-
-        return `${year}-${month}-${day}`;  // 템플릿 리터럴로 최종 문자열 조합
-    }
-
-
-</script>
 </body>
 </html>


### PR DESCRIPTION
## 구현 사항 요약
- 일정 등록 모달 화면, 등록 시 필수값 검증, 연차 타입에 따른 전송 값 설정
- 일정 등록 부분 수정(날짜, 시간 따로받도록) + Entity 테이블 설계 변경에 따른 속성 수정

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  ~~- `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)~~
  - **테이블 없이 조회할 때마다 추출하도록 임시 구현**
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [ ] 프론트
      - [ ] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [ ]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [ ] 프론트
      - [ ] 삭제 확인 모달 추가
      - [ ] Calendar 일정 다시 DB에서 받아오고 갱신

- [ ] 로그인 페이지

- [ ] 연차 사용 현황 페이지

  - [ ] API 리팩토링
    - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
    - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
    - [ ] Query DSL 도입하여 Dto로 응답 바로 받을 수 있는것들 처리 등
    - [ ] 일정 등록, 수정 시 사용한 연차 계산하여 저장
    - [ ] 연차 현황 조회 시 더하는 것으로 수정

- [x] 개인별 연차 사용 현황 조회
  - 테이블 설계 없이 기능 구현

- [ ] 각각의 HTML 도입 및 수정
  - 일정 상세 & 수정 페이지 모달
  - 메인 페이지 헤더
    - 비밀번호 변경
    - 연차 사용 현황
  - 페이지 반응형 등