### PR TITLE
Spring Security 설정 & 로그인 검증 로직 추가

### DIFF
--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -18,6 +19,8 @@ import com.leavebridge.calendar.dto.MonthlyEvent;
 import com.leavebridge.calendar.dto.MonthlyEventDetailResponse;
 import com.leavebridge.calendar.dto.PatchLeaveRequestDto;
 import com.leavebridge.calendar.service.CalendarService;
+import com.leavebridge.member.entitiy.CustomMemberDetails;
+import com.leavebridge.member.entitiy.Member;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,18 +48,22 @@ public class CalendarController {
 	 * 특정 이벤트 상세 조회
 	 */
 	@GetMapping("/events/{eventId}")
-	public ResponseEntity<MonthlyEventDetailResponse> getEventDetail(@PathVariable("eventId") Long eventId) {
-		return ResponseEntity.ok(calendarService.getEventDetails(eventId));
+	public ResponseEntity<MonthlyEventDetailResponse> getEventDetail(@PathVariable("eventId") Long eventId,
+		@AuthenticationPrincipal CustomMemberDetails customMemberDetails) {
+		Member member = (customMemberDetails != null) ? customMemberDetails.getMember() : null;
+		log.info("getEventDetail :: eventId = {}, loginId = {}", eventId, member != null ? member.getLoginId() : "비회원 조회");
+		return ResponseEntity.ok(calendarService.getEventDetails(eventId, member));
 	}
 
 	/**
 	 * 일정 등록
 	 **/
 	@PostMapping("/events")
-	public ResponseEntity<Void> createHolidays(@RequestBody CreateLeaveRequestDto createLeaveRequestDto) throws
-		Exception {
-		log.info("createHolidays :: createLeaveRequestDto = {}", createLeaveRequestDto );
-		calendarService.createTimedEvent(createLeaveRequestDto);
+	public ResponseEntity<Void> createHolidays(@RequestBody CreateLeaveRequestDto createLeaveRequestDto,
+		@AuthenticationPrincipal(expression = "member") Member member) throws Exception {
+		log.info("createHolidays :: createLeaveRequestDto = {}, login Member = {}", createLeaveRequestDto,
+			member.getLoginId());
+		calendarService.createTimedEvent(createLeaveRequestDto, member);
 		return ResponseEntity.ok().build();
 	}
 
@@ -65,9 +72,11 @@ public class CalendarController {
 	 */
 	@PatchMapping("/events/{eventId}")
 	public ResponseEntity<Void> updateHolidays(@PathVariable("eventId") Long eventId,
-		@RequestBody PatchLeaveRequestDto patchLeaveRequestDto) throws IOException {
-		log.info("updateHolidays :: eventId={} patchLeaveRequestDto = {}", eventId, patchLeaveRequestDto );
-		calendarService.updateEventDate(eventId, patchLeaveRequestDto);
+		@RequestBody PatchLeaveRequestDto patchLeaveRequestDto,
+		@AuthenticationPrincipal(expression = "member") Member member) throws IOException {
+		log.info("updateHolidays :: eventId={} patchLeaveRequestDto = {} login Id = {}", eventId, patchLeaveRequestDto,
+			member.getLoginId());
+		calendarService.updateEventDate(eventId, patchLeaveRequestDto, member);
 		return ResponseEntity.ok().build();
 	}
 
@@ -75,8 +84,10 @@ public class CalendarController {
 	 * 특정 이벤트 삭제
 	 */
 	@DeleteMapping("/events/{eventId}")
-	public ResponseEntity<Void> deleteHolidays(@PathVariable("eventId") Long eventId) throws IOException {
-		calendarService.deleteEvent(eventId);
+	public ResponseEntity<Void> deleteHolidays(@PathVariable("eventId") Long eventId,
+		@AuthenticationPrincipal(expression = "member") Member member) throws IOException {
+		log.info("deleteHolidays :: eventId={} member = {}", eventId, member.getLoginId());
+		calendarService.deleteEvent(eventId, member);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -34,8 +34,8 @@ public class CalendarController {
 	 * 이번달 구글 캘린더 등록 이벤트 조회
 	 */
 	@GetMapping("/events/{year}/{month}")
-	public ResponseEntity<List<MonthlyEvent>> getUpcomingEvents(@PathVariable Integer year,
-		@PathVariable Integer month) throws Exception {
+	public ResponseEntity<List<MonthlyEvent>> getUpcomingEvents(@PathVariable("year") Integer year,
+		@PathVariable("month") Integer month) throws Exception {
 		log.info("getUpcomingEvents :: year={}, month={}", year, month);
 		List<MonthlyEvent> events = calendarService.listMonthlyEvents(year, month);
 		return ResponseEntity.ok(events);

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -170,4 +170,13 @@ public class LeaveAndHoliday {
 	public void onPrePersist() {
 		this.updatedDate = null;
 	}
+
+	// 프록시 객체 (leaveAndHoliday 속 member) 는 id는 가지고 있으니 쿼리 없이 검사하기 위함
+	public boolean isOwnedBy(Member member) {
+		return member != null && this.member.getId().equals(member.getId());
+	}
+
+	public boolean canModifyLeave(){
+		return !leaveType.equals(LeaveType.HOLIDAY) && !leaveType.equals(LeaveType.OTHER_PEOPLE);
+	}
 }

--- a/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
+++ b/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
@@ -37,7 +37,7 @@ public class CalendarScheduler {
 	@Value("${google.calendar-id}")
 	private String GOOGLE_PERSONAL_CALENDAR_ID;
 
-	private final Member dummyMember = Member.builder().id(4L).build();
+	private final Member adminMember = Member.builder().id(4L).build();
 
 	private final static String GOOGLE_KOREA_HOLIDAY_CALENDAR_ID = "ko.south_korea#holiday@group.v.calendar.google.com";
 
@@ -105,7 +105,7 @@ public class CalendarScheduler {
 		// 3) 신규 이벤트만 매핑 후 저장
 		List<LeaveAndHoliday> toSave = events.stream()
 			.filter(e -> !existingIds.contains(e.getId()))
-			.map(e -> LeaveAndHoliday.of(e, dummyMember, type))
+			.map(e -> LeaveAndHoliday.of(e, adminMember, type))
 			.sorted(Comparator.comparing(LeaveAndHoliday::getStartDate))
 			.toList();
 

--- a/src/main/java/com/leavebridge/config/SecurityConfig.java
+++ b/src/main/java/com/leavebridge/config/SecurityConfig.java
@@ -24,13 +24,13 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
 				// .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-				// .requestMatchers(HttpMethod.POST, "/api/*/member/login").permitAll() // 로그인은 누구나 가능
-				// .requestMatchers(HttpMethod.GET, "/").permitAll() // 메인 페이지 누구나 가능
-				// // 예외 처리 로직 없을 때 Tomcat이 포워딩 하는 경로 접근 허용하여 예외 메세지 잘 전달되도록 허용
+				.requestMatchers("/", "/member/login", "/css/**", "/js/**").permitAll()
+				.requestMatchers("/api/*/calendar/events/*/*").permitAll() // 일정 조회
+				.requestMatchers("/member/login").permitAll() // 메인 페이지 누구나 가능
+				.requestMatchers("/usage").permitAll() // 연차 사용 현황 누구나 가능
 				.requestMatchers("/error").permitAll()
-				.anyRequest().permitAll() // 나머지는 인증된 사용자만 가능
+				.anyRequest().authenticated() // 나머지는 인증된 사용자만 가능
 			)
-			.csrf(csrf -> csrf.disable())
 			.logout(
 				logout -> logout
 					.logoutUrl("/member/logout")
@@ -42,7 +42,8 @@ public class SecurityConfig {
 			.formLogin(
 				formLogin -> formLogin
 					.loginPage("/member/login")
-					.defaultSuccessUrl("/")
+					.permitAll()
+					.defaultSuccessUrl("/", true)
 			)
 		;
 		return http.build();

--- a/src/main/java/com/leavebridge/home/HomeController.java
+++ b/src/main/java/com/leavebridge/home/HomeController.java
@@ -1,13 +1,19 @@
 package com.leavebridge.home;
 
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
 
 	@GetMapping("/")
-	public String home() {
+	public String home(Model model, Authentication authentication) {
+		boolean isAuthenticated = authentication != null && authentication.isAuthenticated()
+								  && !(authentication instanceof AnonymousAuthenticationToken);
+		model.addAttribute("isAuthenticated", isAuthenticated);
 		return "calendar/home";
 	}
 }

--- a/src/main/java/com/leavebridge/member/entitiy/CustomMemberDetails.java
+++ b/src/main/java/com/leavebridge/member/entitiy/CustomMemberDetails.java
@@ -1,0 +1,32 @@
+package com.leavebridge.member.entitiy;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomMemberDetails implements UserDetails {
+
+	// 현재 인증된 Member 정보 저장
+	private final Member member;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return member.getGrantedAuthorities();
+	}
+
+	@Override
+	public String getPassword() {
+		return member.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return member.getLoginId();
+	}
+}

--- a/src/main/java/com/leavebridge/member/entitiy/Member.java
+++ b/src/main/java/com/leavebridge/member/entitiy/Member.java
@@ -73,4 +73,8 @@ public class Member {
 	public void onPrePersist() {
 		this.updatedDate = null;
 	}
+
+	public boolean isAdmin() {
+		return this.memberRole == MemberRole.ADMIN;
+	}
 }

--- a/src/main/java/com/leavebridge/member/entitiy/Member.java
+++ b/src/main/java/com/leavebridge/member/entitiy/Member.java
@@ -1,20 +1,24 @@
 package com.leavebridge.member.entitiy;
 
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,9 +52,25 @@ public class Member {
 	@ToString.Exclude
 	private List<LeaveAndHoliday> leaveAndHolidays;
 
+	@Column(name = "MEMBER_ROLE")
+	@Enumerated(EnumType.STRING)
+	private MemberRole memberRole;
+
+	@Column(name = "CREATED_DATE")
+	@CreatedDate
+	private LocalDateTime createdDate = LocalDateTime.now();
+
+	@Column(name = "UPDATED_DATE")
+	@LastModifiedDate
+	private LocalDateTime updatedDate;
+
 	public List<? extends GrantedAuthority> getGrantedAuthorities() {
-		List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
-		grantedAuthorities.add(new SimpleGrantedAuthority("member"));
-		return grantedAuthorities;
+		return List.of(memberRole);
+	}
+
+	// 최초 생성 시 updatedDate는 null로
+	@PrePersist // 영속화 되기 직전 한번만 실행
+	public void onPrePersist() {
+		this.updatedDate = null;
 	}
 }

--- a/src/main/java/com/leavebridge/member/entitiy/MemberRole.java
+++ b/src/main/java/com/leavebridge/member/entitiy/MemberRole.java
@@ -1,0 +1,21 @@
+package com.leavebridge.member.entitiy;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum MemberRole implements GrantedAuthority {
+
+	MEMBER("일반 회원"),
+	ADMIN("관리자");
+
+	private final String description;
+
+	@Override
+	public String getAuthority() {
+		return this.name();
+	}
+}

--- a/src/main/java/com/leavebridge/member/repository/MemberRepository.java
+++ b/src/main/java/com/leavebridge/member/repository/MemberRepository.java
@@ -15,7 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         select distinct m
         from Member m
         left join fetch m.leaveAndHolidays l
-        where m.name not like '%마스터유저%'
+        where m.id != 4
         """)
 	List<Member> findAllWithLeaves();
 }

--- a/src/main/java/com/leavebridge/member/service/MemberSecurityService.java
+++ b/src/main/java/com/leavebridge/member/service/MemberSecurityService.java
@@ -6,24 +6,27 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.leavebridge.member.entitiy.CustomMemberDetails;
 import com.leavebridge.member.entitiy.Member;
 import com.leavebridge.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class MemberSecurityService implements UserDetailsService {
 
 	private final MemberRepository memberRepository;
 
 	@Override
-	// 사용자명으로 비밀번호를 조회하여 리턴하는 메서드
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		log.info("loadUserByUsername :: {}", username);
 		Member member = memberRepository.findByLoginId(username).orElseThrow(
 			() -> new IllegalArgumentException("사용자를 찾을수 없습니다.")
 		);
-
-		return new User(member.getLoginId(), member.getPassword(), member.getGrantedAuthorities());
+		// Custom에서 권한, 비밀번호 넘겨줌 -> DaoAuthenticationProvider가 인증 하도록
+		return new CustomMemberDetails(member);
 	}
 }

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -176,18 +176,6 @@
     <div id='calendar'></div>
 
     <script>
-
-        // Vanilla JS로 CSRF 메타 태그를 꺼내되, 없으면 빈 문자열('')
-        const header = document
-                .querySelector("meta[name='_csrf_header']")
-                ?.getAttribute("content")
-            ?? "";
-
-        const token = document
-                .querySelector("meta[name='_csrf']")
-                ?.getAttribute("content")
-            ?? "";
-
         /**
          * 오늘 날짜를 'YYYY-MM-DD' 형식의 문자열로 반환합니다.
          * @returns {string} 포맷된 날짜 문자열
@@ -538,6 +526,11 @@
 
                 // 날짜나 시간 클릭 시 발생 -> 일정 생성 폼 등록
                 dateClick: function (info) {
+                    // ➊ 로그인하지 않은 경우
+                    if (!window.isAuthenticated) {
+                        showToast('일정 등록은 로그인 후 가능합니다.', 'warning');
+                        return;
+                    }
                     // 등록 모드 진입 시 기존 ID 초기화
                     currentEventId = null;
                     // 전역 변수에 클릭한 날짜 저장

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -88,6 +88,37 @@
 </div>
 <!-- 공통 스크립트 -->
 <script>
+
+    // fetch 요청 리다이렉트 적용되도록 오버라이드
+    (() => {
+        // 원본 fetch 저장
+        const _fetch = window.fetch;
+
+        // 전역 fetch 오버라이드
+        window.fetch = function(input, init = {}) {
+            // credentials: 'include' 를 기본값으로 추가(쿠키 인증을 위해)
+            init.credentials = init.credentials || 'include';
+
+            return _fetch(input, init)
+                .then(response => {
+                    // 401 Unauthorized 또는 리다이렉트 감지
+                    if (response.status === 401 || response.redirected) {
+                        // 로그인 페이지로 전체 네비게이션
+                        window.location.href = '/member/login';
+                        // 이후 체인 중단
+                        return Promise.reject(new Error('Redirecting to login'));
+                    }
+                    return response;
+                })
+                .catch(err => {
+                    // 네트워크 오류 등도 여기서 처리 가능
+                    console.error('Global fetch error:', err);
+                    throw err;
+                });
+        };
+    })();
+
+
     // Vanilla JS로 CSRF 메타 태그를 꺼내되, 없으면 빈 문자열('')
     const header = document
             .querySelector("meta[name='_csrf_header']")

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -53,6 +53,12 @@
     <!-- 부트스트랩 모달까지 사용하기 위함 -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
 
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        window.isAuthenticated = /*[[${isAuthenticated}]]*/ false;
+        /*]]>*/
+    </script>
+
 </head>
 <body class="d-flex flex-column vh-100">
 

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -4,6 +4,9 @@
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- CSRF 메타태그를 실제 값으로 렌더링 -->
+    <meta th:name="'_csrf'"        th:content="${_csrf.token}"      />
+    <meta th:name="'_csrf_header'" th:content="${_csrf.headerName}" />
     <title>LeaveBridge</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet"/>
@@ -79,6 +82,17 @@
 </div>
 <!-- 공통 스크립트 -->
 <script>
+    // Vanilla JS로 CSRF 메타 태그를 꺼내되, 없으면 빈 문자열('')
+    const header = document
+            .querySelector("meta[name='_csrf_header']")
+            ?.getAttribute("content")
+        ?? "";
+
+    const token = document
+            .querySelector("meta[name='_csrf']")
+            ?.getAttribute("content")
+        ?? "";
+
     // 1) 기본 헤더
     const requestHeaders = {
         'Content-Type': 'application/json'


### PR DESCRIPTION
## 구현 사항 요약

- Spring Security 설정 변경
  -  비로그인 회원 권한 허용 API 명시
  - CSRF 토큰 활성화

- Member 엔티티 속성 변경
  - Security Role 추가

- `CustomUserDetails` 도입하여 `Member` 찾기 위해 쿼리 2번 나가지 않고 Authentication 객체에 저장해서 사용
  -  1차 캐시에 key가 entity의 id기에 loginId로 검색 시 1차 캐시 못타고 추가 쿼리 발생 방지

- 일정 로직에 회원 검증 로직 추가

- 홈 화면 진입 시 로그인 여부 넘겨줌
  - 일정 클릭 시 일정 등록 모달 안뜨게 하기 위함

- JS fetch 함수 시 redirect 안되던 것 수정

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  ~~- `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)~~
  - **테이블 없이 조회할 때마다 추출하도록 임시 구현**
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신

- [x] 로그인 페이지

- [ ] 연차 사용 현황 페이지

- [ ] 비밀번호 변경 페이지

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [ ] API 리팩토링
  - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [ ] Query DSL 도입하여 Dto로 응답 바로 받을 수 있는것들 처리 등
  - [ ] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [ ] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현
