### PR TITLE
공휴일 데이터 가져오는 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,13 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        // Spring Cloud 2023.0.5 (Leyton) 트레인 – Spring Boot 3.3.x 호환
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.5"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
@@ -54,6 +61,9 @@ dependencies {
 
     //p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+    // openfeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 }

--- a/src/main/java/com/leavebridge/LeaveBridgeApplication.java
+++ b/src/main/java/com/leavebridge/LeaveBridgeApplication.java
@@ -4,6 +4,7 @@ import java.util.TimeZone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableRetry
 @EnableJpaAuditing
+@EnableFeignClients(basePackages = "com.leavebridge.calendar.api")
 public class LeaveBridgeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/leavebridge/calendar/api/AnniversaryClient.java
+++ b/src/main/java/com/leavebridge/calendar/api/AnniversaryClient.java
@@ -1,0 +1,38 @@
+package com.leavebridge.calendar.api;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.leavebridge.calendar.api.dto.RequestQueryParams;
+import com.leavebridge.calendar.api.dto.ResponseWrapper;
+import com.leavebridge.config.FeignConfig;
+
+@FeignClient(
+	name = "anniversaryApi",
+	url  = "http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService",
+	configuration = FeignConfig.class  // Null 파람 무시
+)
+public interface AnniversaryClient {
+
+	// 국경일 데이터
+	@GetMapping(value = "/getHoliDeInfo", produces = "application/json")
+	ResponseWrapper getHolidays(@SpringQueryMap RequestQueryParams params);
+
+	// 공휴일 데이터
+	@GetMapping(value = "/getRestDeInfo", produces = "application/json")
+	ResponseWrapper getRestDeInfo(@SpringQueryMap RequestQueryParams params);
+
+	// 기념일 데이터
+	@GetMapping(value = "/getAnniversaryInfo", produces = "application/json")
+	ResponseWrapper getAnniversaryInfo(@SpringQueryMap RequestQueryParams params);
+
+	// 24절기 정보 조회
+	@GetMapping(value = "/get24DivisionsInfo", produces = "application/json")
+	ResponseWrapper get24DivisionsInfo(@SpringQueryMap RequestQueryParams params);
+
+	// 잡절 정보 조회
+	@GetMapping(value = "/getSundryDayInfo", produces = "application/json")
+	ResponseWrapper getSundryDayInfo(@SpringQueryMap RequestQueryParams params);
+}

--- a/src/main/java/com/leavebridge/calendar/api/dto/RequestQueryParams.java
+++ b/src/main/java/com/leavebridge/calendar/api/dto/RequestQueryParams.java
@@ -1,0 +1,16 @@
+package com.leavebridge.calendar.api.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+@Getter // @SpringQueryMap은 빈(Bean) 프로퍼티의 getter를 통해 각 필드 값을 읽어서 쿼리 파라미터로 변환
+@Builder
+@Value // 왠지 모르겠는데 무조건 이녀석 있어야 정상 동작..
+public class RequestQueryParams {
+	String serviceKey;
+	String solYear;
+	String solMonth;
+	String _type;
+	String numOfRows;
+}

--- a/src/main/java/com/leavebridge/calendar/api/dto/ResponseWrapper.java
+++ b/src/main/java/com/leavebridge/calendar/api/dto/ResponseWrapper.java
@@ -1,0 +1,33 @@
+package com.leavebridge.calendar.api.dto;
+
+import java.util.List;
+
+public record ResponseWrapper(
+	Response response
+) {
+	public record Response(
+		Header header,
+		Body   body
+	) {}
+
+	public record Header(
+		String resultCode,
+		String resultMsg
+	) {}
+
+	public record Body(
+		Items items     // 페이징 필드 제거
+	) {}
+
+	public record Items(
+		List<Item> item
+	) {}
+
+	public record Item(
+		Integer locdate,
+		Integer seq,
+		String  dateKind,
+		String  isHoliday,
+		String  dateName
+	) {}
+}

--- a/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
@@ -45,7 +45,7 @@ public record CreateLeaveRequestDto(
 			// 타입이 전일 전용이면 강제 전일
 			if (leaveType == LeaveType.FULL_DAY_LEAVE ||
 				leaveType == LeaveType.SUMMER_VACATION ||
-				leaveType == LeaveType.HOLIDAY) {
+				leaveType == LeaveType.PUBLIC_HOLIDAY) {
 				isAllDay = true;
 			}
 		}

--- a/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
@@ -46,7 +46,7 @@ public record PatchLeaveRequestDto(
 			// 타입이 전일 전용이면 강제 전일
 			if (leaveType == LeaveType.FULL_DAY_LEAVE ||
 				leaveType == LeaveType.SUMMER_VACATION ||
-				leaveType == LeaveType.HOLIDAY) {
+				leaveType == LeaveType.PUBLIC_HOLIDAY) {
 				isAllDay = true;
 			}
 		}

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -93,6 +93,9 @@ public class LeaveAndHoliday {
 	@LastModifiedDate
 	private LocalDateTime updatedDate;
 
+	@Column(name = "IS_HOLIDAY")
+	private Boolean isHoliday;
+
 	public static LeaveAndHoliday of(Event event, Member member, LeaveType leaveType) {
 
 		LocalDateTime start = DateUtils.parseDateTime(event.getStart(), true);
@@ -177,6 +180,6 @@ public class LeaveAndHoliday {
 	}
 
 	public boolean canModifyLeave(){
-		return !leaveType.equals(LeaveType.HOLIDAY) && !leaveType.equals(LeaveType.OTHER_PEOPLE);
+		return !leaveType.equals(LeaveType.PUBLIC_HOLIDAY) && !leaveType.equals(LeaveType.OTHER_PEOPLE);
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
+++ b/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum LeaveType {
-	HOLIDAY("공휴일", false),
+	PUBLIC_HOLIDAY("공휴일", false),
+
+	ANNIVERSARY("기념일", false),
 
 	FULL_DAY_LEAVE("1일 연차", true),
 

--- a/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
+++ b/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
@@ -8,6 +8,12 @@ import lombok.RequiredArgsConstructor;
 public enum LeaveType {
 	PUBLIC_HOLIDAY("공휴일", false),
 
+	NATIONAL_HOLIDAY("국경일", false),
+
+	TWENTY_FOUR_SOLAR_TERMS("24절기", false),
+
+	SUNDRY_DAY("잡절", false),
+
 	ANNIVERSARY("기념일", false),
 
 	FULL_DAY_LEAVE("1일 연차", true),

--- a/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
+++ b/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
@@ -12,4 +12,5 @@ import com.leavebridge.calendar.entity.LeaveAndHoliday;
 public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday, Long> {
 	List<LeaveAndHoliday> findAllByGoogleEventIdIn(List<String> eventIds);
 	List<LeaveAndHoliday> findAllByStartDateGreaterThanEqualAndStartDateLessThan(LocalDate start, LocalDate end);
+	List<LeaveAndHoliday> findAllByStartDateBetween(LocalDate yearStart, LocalDate yearEnd);
 }

--- a/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
+++ b/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
@@ -1,18 +1,5 @@
 package com.leavebridge.calendar.scheduler;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.util.Comparator;
-import java.util.List;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.model.Event;
@@ -21,114 +8,149 @@ import com.leavebridge.calendar.entity.LeaveAndHoliday;
 import com.leavebridge.calendar.enums.LeaveType;
 import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
 import com.leavebridge.member.entitiy.Member;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Slf4j
 @Service
 public class CalendarScheduler {
 
-	private final Calendar calendarClient;
-	private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
-	private final LeaveAndHolidayRepository leaveAndHolidayRepository;
+    private final Calendar calendarClient;
+    private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
+    private final LeaveAndHolidayRepository leaveAndHolidayRepository;
 
-	@Value("${google.calendar-id}")
-	private String GOOGLE_PERSONAL_CALENDAR_ID;
+    @Value("${google.calendar-id}")
+    private String GOOGLE_PERSONAL_CALENDAR_ID;
 
-	private final Member adminMember = Member.builder().id(4L).build();
+    private final Member adminMember = Member.builder().id(4L).build();
 
-	private final static String GOOGLE_KOREA_HOLIDAY_CALENDAR_ID = "ko.south_korea#holiday@group.v.calendar.google.com";
+    private final static String GOOGLE_KOREA_HOLIDAY_CALENDAR_ID = "ko.south_korea#holiday@group.v.calendar.google.com";
 
-	// @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
-	@Scheduled(cron = "0 0 0 * * *")
-	@Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
-	public void getLeaveSchduleRegularly() throws IOException {
+    // @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
+    @Scheduled(cron = "0 0 0 * * *")
+    @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+    public void getLeaveSchduleRegularly() throws IOException {
 
-		LocalDate today = LocalDate.now();
-		int year = today.getYear();
-		int month = today.getMonthValue();
+        LocalDate today = LocalDate.now();
+        int year = today.getYear();
+        int month = today.getMonthValue();
 
-		log.info("getLeaveSchduleRegularly {}", year + "-" + month);
+        log.info("getLeaveSchduleRegularly {}", year + "-" + month);
 
-		// 월 시작: yyyy-MM-01T00:00:00Z
-		DateTime timeMin = new DateTime(String.format("%04d-%02d-01T00:00:00Z", year, month));
+        // 월 시작: yyyy-MM-01T00:00:00Z
+        DateTime timeMin = new DateTime(String.format("%04d-%02d-01T00:00:00Z", year, month));
 
-		// 1) YearMonth로 말일(LocalDate) 구하기
-		YearMonth ym = YearMonth.of(year, month);
-		LocalDate lastDayDate = ym.atEndOfMonth();
+        // 1) YearMonth로 말일(LocalDate) 구하기
+        YearMonth ym = YearMonth.of(year, month);
+        LocalDate lastDayDate = ym.atEndOfMonth();
 
-		// 2) 말일 자정(UTC)을 포함한 ISO 8601 문자열 생성
-		String timeMaxIso = String.format("%sT23:59:59Z", lastDayDate);
+        // 2) 말일 자정(UTC)을 포함한 ISO 8601 문자열 생성
+        String timeMaxIso = String.format("%sT23:59:59Z", lastDayDate);
 
-		// 3) DateTime 객체로 변환
-		DateTime timeMax = new DateTime(timeMaxIso);
+        // 3) DateTime 객체로 변환
+        DateTime timeMax = new DateTime(timeMaxIso);
 
-		Events events = calendarClient.events().list(GOOGLE_PERSONAL_CALENDAR_ID)
-			.setTimeMin(timeMin)
-			.setTimeMax(timeMax)
-			.setSingleEvents(true)    // 반복 이벤트를 각 회차별로 개별 인스턴스로 분할해 반환
-			.setOrderBy("startTime")
-			.execute();
+        Events events = calendarClient.events().list(GOOGLE_PERSONAL_CALENDAR_ID)
+                .setTimeMin(timeMin)
+                .setTimeMax(timeMax)
+                .setSingleEvents(true)    // 반복 이벤트를 각 회차별로 개별 인스턴스로 분할해 반환
+                .setOrderBy("startTime")
+                .execute();
 
-		List<Event> items = events.getItems();
+        List<Event> items = events.getItems();
 
-		processAndSaveNewEvents(items, LeaveType.OTHER_PEOPLE);
-	}
+        processAndSaveNewEvents(items, LeaveType.OTHER_PEOPLE);
+    }
 
-	// @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
-	@Scheduled(cron = "0 0 4 1 * *")
-	@Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
-	public void getHolidaysRegularly() throws IOException {
+    // @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
+    @Scheduled(cron = "0 0 4 1 * *")
+    @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+    public void getHolidaysRegularly() throws IOException {
 
-		log.info("getHolidaysRegularly :: {}", LocalDateTime.now());
+        log.info("getHolidaysRegularly :: {}", LocalDateTime.now());
 
-		Events holidaysEvents = calendarClient.events().list(GOOGLE_KOREA_HOLIDAY_CALENDAR_ID).execute();
+        Events holidaysEvents = calendarClient.events().list(GOOGLE_KOREA_HOLIDAY_CALENDAR_ID).execute();
 
-		List<Event> items = holidaysEvents.getItems();
+        List<Event> items = holidaysEvents.getItems();
 
-		processAndSaveNewEvents(items, LeaveType.HOLIDAY);
-	}
+        processAndSaveNewEvents(items, null);
+    }
 
-	private void processAndSaveNewEvents(List<Event> events, LeaveType type) {
-		if (events.isEmpty()) {
-			return;
-		}
+    private void processAndSaveNewEvents(List<Event> events, LeaveType leaveType) throws IOException {
+        if (events.isEmpty()) {
+            return;
+        }
 
-		// 1) 이벤트 ID 추출
-		List<String> eventIds = extractEventIds(events);
+        // 1) 이벤트 ID 추출
+        List<String> eventIds = extractEventIds(events);
 
-		// 2) DB에 이미 있는 ID 조회
-		List<String> existingIds = findExistingEventIds(eventIds);
+        // 2) DB에 이미 있는 ID 조회
+        List<String> existingIds = findExistingEventIds(eventIds);
 
-		// 3) 신규 이벤트만 매핑 후 저장
-		List<LeaveAndHoliday> toSave = events.stream()
-			.filter(e -> !existingIds.contains(e.getId()))
-			.map(e -> LeaveAndHoliday.of(e, adminMember, type))
-			.sorted(Comparator.comparing(LeaveAndHoliday::getStartDate))
-			.toList();
+        // 3) 신규 이벤트만 매핑 후 저장
+        List<Event> targetSaveList = events.stream()
+                .filter(e -> !existingIds.contains(e.getId()))
+                .toList();
 
-		leaveAndHolidayRepository.saveAll(toSave);
-	}
+        // 4) 공휴일, 기념일 매핑 or 비회원 연차인지 구분
+        List<LeaveAndHoliday> newEntityList = targetSaveList.stream()
+                .map(e -> {
 
-	/**
-	 * 이벤트 리스트에서 Google Event ID만 추출
-	 */
-	private List<String> extractEventIds(List<Event> events) {
-		return events.stream()
-			.map(Event::getId)
-			.toList();
-	}
+                    if (leaveType != null) {
+                        return LeaveAndHoliday.of(e, adminMember, leaveType);
+                    }
 
-	/**
-	 * DB에 이미 저장된 Google Event ID 목록 조회
-	 */
-	private List<String> findExistingEventIds(List<String> eventIds) {
-		return leaveAndHolidayRepository
-			.findAllByGoogleEventIdIn(eventIds)
-			.stream()
-			.map(LeaveAndHoliday::getGoogleEventId)
-			.toList();
-	}
+                    String description = e.getDescription();
+
+                    if ("공휴일".equals(description)) {
+                        return LeaveAndHoliday.of(e, adminMember, LeaveType.PUBLIC_HOLIDAY);
+                    }
+
+                    if (description != null && description.contains("기념일")) {
+                        return LeaveAndHoliday.of(e, adminMember, LeaveType.ANNIVERSARY);
+                    }
+
+                    // 그 외는 패스
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(LeaveAndHoliday::getStartDate))
+                .toList();
+
+        leaveAndHolidayRepository.saveAll(newEntityList);
+    }
+
+    /**
+     * 이벤트 리스트에서 Google Event ID만 추출
+     */
+    private List<String> extractEventIds(List<Event> events) {
+        return events.stream()
+                .map(Event::getId)
+                .toList();
+    }
+
+    /**
+     * DB에 이미 저장된 Google Event ID 목록 조회
+     */
+    private List<String> findExistingEventIds(List<String> eventIds) {
+        return leaveAndHolidayRepository
+                .findAllByGoogleEventIdIn(eventIds)
+                .stream()
+                .map(LeaveAndHoliday::getGoogleEventId)
+                .toList();
+    }
 }

--- a/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
+++ b/src/main/java/com/leavebridge/calendar/scheduler/CalendarScheduler.java
@@ -1,156 +1,87 @@
 package com.leavebridge.calendar.scheduler;
 
-import com.google.api.client.util.DateTime;
-import com.google.api.services.calendar.Calendar;
-import com.google.api.services.calendar.model.Event;
-import com.google.api.services.calendar.model.Events;
-import com.leavebridge.calendar.entity.LeaveAndHoliday;
-import com.leavebridge.calendar.enums.LeaveType;
-import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
-import com.leavebridge.member.entitiy.Member;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.Events;
+import com.leavebridge.calendar.entity.LeaveAndHoliday;
+import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
+import com.leavebridge.calendar.service.ExternalEventSyncService;
+import com.leavebridge.member.entitiy.Member;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
 @Service
 public class CalendarScheduler {
 
-    private final Calendar calendarClient;
-    private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
-    private final LeaveAndHolidayRepository leaveAndHolidayRepository;
+	private final Calendar calendarClient;
+	private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
+	private final LeaveAndHolidayRepository leaveAndHolidayRepository;
+	private final ExternalEventSyncService externalEventSyncService;
 
-    @Value("${google.calendar-id}")
-    private String GOOGLE_PERSONAL_CALENDAR_ID;
+	@Value("${google.calendar-id}")
+	private String GOOGLE_PERSONAL_CALENDAR_ID;
 
-    private final Member adminMember = Member.builder().id(4L).build();
+	public static Member adminMember = Member.builder().id(4L).build();
 
-    private final static String GOOGLE_KOREA_HOLIDAY_CALENDAR_ID = "ko.south_korea#holiday@group.v.calendar.google.com";
+	// @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
+	@Scheduled(cron = "0 0 0 * * *")
+	@Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+	public void getLeaveSchduleRegularly() throws IOException {
 
-    // @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
-    @Scheduled(cron = "0 0 0 * * *")
-    @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
-    public void getLeaveSchduleRegularly() throws IOException {
+		LocalDate today = LocalDate.now();
+		int year = today.getYear();
+		int month = today.getMonthValue();
 
-        LocalDate today = LocalDate.now();
-        int year = today.getYear();
-        int month = today.getMonthValue();
+		log.info("getLeaveSchduleRegularly {}", year + "-" + month);
 
-        log.info("getLeaveSchduleRegularly {}", year + "-" + month);
+		// 월 시작: yyyy-MM-01T00:00:00Z
+		DateTime timeMin = new DateTime(String.format("%04d-%02d-01T00:00:00Z", year, month));
 
-        // 월 시작: yyyy-MM-01T00:00:00Z
-        DateTime timeMin = new DateTime(String.format("%04d-%02d-01T00:00:00Z", year, month));
+		// 1) YearMonth로 말일(LocalDate) 구하기
+		YearMonth ym = YearMonth.of(year, month);
+		LocalDate lastDayDate = ym.atEndOfMonth();
 
-        // 1) YearMonth로 말일(LocalDate) 구하기
-        YearMonth ym = YearMonth.of(year, month);
-        LocalDate lastDayDate = ym.atEndOfMonth();
+		// 2) 말일 자정(UTC)을 포함한 ISO 8601 문자열 생성
+		String timeMaxIso = String.format("%sT23:59:59Z", lastDayDate);
 
-        // 2) 말일 자정(UTC)을 포함한 ISO 8601 문자열 생성
-        String timeMaxIso = String.format("%sT23:59:59Z", lastDayDate);
+		// 3) DateTime 객체로 변환
+		DateTime timeMax = new DateTime(timeMaxIso);
 
-        // 3) DateTime 객체로 변환
-        DateTime timeMax = new DateTime(timeMaxIso);
+		Events events = calendarClient.events().list(GOOGLE_PERSONAL_CALENDAR_ID)
+			.setTimeMin(timeMin)
+			.setTimeMax(timeMax)
+			.setSingleEvents(true)    // 반복 이벤트를 각 회차별로 개별 인스턴스로 분할해 반환
+			.setOrderBy("startTime")
+			.execute();
 
-        Events events = calendarClient.events().list(GOOGLE_PERSONAL_CALENDAR_ID)
-                .setTimeMin(timeMin)
-                .setTimeMax(timeMax)
-                .setSingleEvents(true)    // 반복 이벤트를 각 회차별로 개별 인스턴스로 분할해 반환
-                .setOrderBy("startTime")
-                .execute();
+		List<Event> items = events.getItems();
 
-        List<Event> items = events.getItems();
+		externalEventSyncService.processAndSaveNewEvents(items);
+	}
 
-        processAndSaveNewEvents(items, LeaveType.OTHER_PEOPLE);
-    }
+	// @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
+	@Scheduled(cron = "0 0 4 1 * *") // 매달 1일 새벽 4시 실행
+	@Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+	public void syncHolidaysMonthly() throws IOException {
+		log.info("syncHolidaysMonthly :: {}", LocalDateTime.now());
+		List<LeaveAndHoliday> sortedNewLeaveAndHolidayEntities = externalEventSyncService.syncNextYears(2);
+		leaveAndHolidayRepository.saveAll(sortedNewLeaveAndHolidayEntities);
+	}
 
-    // @Scheduled(cron = "0 */1 * * * *") //1분마다 적용 확인을 위해 일단 달아둠
-    @Scheduled(cron = "0 0 4 1 * *")
-    @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
-    public void getHolidaysRegularly() throws IOException {
-
-        log.info("getHolidaysRegularly :: {}", LocalDateTime.now());
-
-        Events holidaysEvents = calendarClient.events().list(GOOGLE_KOREA_HOLIDAY_CALENDAR_ID).execute();
-
-        List<Event> items = holidaysEvents.getItems();
-
-        processAndSaveNewEvents(items, null);
-    }
-
-    private void processAndSaveNewEvents(List<Event> events, LeaveType leaveType) throws IOException {
-        if (events.isEmpty()) {
-            return;
-        }
-
-        // 1) 이벤트 ID 추출
-        List<String> eventIds = extractEventIds(events);
-
-        // 2) DB에 이미 있는 ID 조회
-        List<String> existingIds = findExistingEventIds(eventIds);
-
-        // 3) 신규 이벤트만 매핑 후 저장
-        List<Event> targetSaveList = events.stream()
-                .filter(e -> !existingIds.contains(e.getId()))
-                .toList();
-
-        // 4) 공휴일, 기념일 매핑 or 비회원 연차인지 구분
-        List<LeaveAndHoliday> newEntityList = targetSaveList.stream()
-                .map(e -> {
-
-                    if (leaveType != null) {
-                        return LeaveAndHoliday.of(e, adminMember, leaveType);
-                    }
-
-                    String description = e.getDescription();
-
-                    if ("공휴일".equals(description)) {
-                        return LeaveAndHoliday.of(e, adminMember, LeaveType.PUBLIC_HOLIDAY);
-                    }
-
-                    if (description != null && description.contains("기념일")) {
-                        return LeaveAndHoliday.of(e, adminMember, LeaveType.ANNIVERSARY);
-                    }
-
-                    // 그 외는 패스
-                    return null;
-                })
-                .filter(Objects::nonNull)
-                .sorted(Comparator.comparing(LeaveAndHoliday::getStartDate))
-                .toList();
-
-        leaveAndHolidayRepository.saveAll(newEntityList);
-    }
-
-    /**
-     * 이벤트 리스트에서 Google Event ID만 추출
-     */
-    private List<String> extractEventIds(List<Event> events) {
-        return events.stream()
-                .map(Event::getId)
-                .toList();
-    }
-
-    /**
-     * DB에 이미 저장된 Google Event ID 목록 조회
-     */
-    private List<String> findExistingEventIds(List<String> eventIds) {
-        return leaveAndHolidayRepository
-                .findAllByGoogleEventIdIn(eventIds)
-                .stream()
-                .map(LeaveAndHoliday::getGoogleEventId)
-                .toList();
-    }
 }

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 
+import com.google.api.services.calendar.model.Events;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -207,7 +208,7 @@ public class CalendarService {
 	 * 공휴일 검증
 	 */
 	private void checkHolidayUpdateAllowed(LeaveAndHoliday leaveAndHoliday) {
-		if (leaveAndHoliday.getLeaveType() == LeaveType.HOLIDAY || leaveAndHoliday.getLeaveType() == LeaveType.OTHER_PEOPLE) {
+		if (leaveAndHoliday.getLeaveType() == LeaveType.PUBLIC_HOLIDAY || leaveAndHoliday.getLeaveType() == LeaveType.OTHER_PEOPLE) {
 			throw new IllegalArgumentException("공휴일 이벤트와 비회원 이벤트는 조작할 수 없습니다.");
 		}
 	}

--- a/src/main/java/com/leavebridge/calendar/service/ExternalEventSyncService.java
+++ b/src/main/java/com/leavebridge/calendar/service/ExternalEventSyncService.java
@@ -1,0 +1,216 @@
+package com.leavebridge.calendar.service;
+
+import static com.leavebridge.calendar.scheduler.CalendarScheduler.*;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.api.services.calendar.model.Event;
+import com.leavebridge.calendar.api.AnniversaryClient;
+import com.leavebridge.calendar.api.dto.RequestQueryParams;
+import com.leavebridge.calendar.api.dto.ResponseWrapper;
+import com.leavebridge.calendar.entity.LeaveAndHoliday;
+import com.leavebridge.calendar.enums.LeaveType;
+import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExternalEventSyncService {
+	private final AnniversaryClient client;
+	private final LeaveAndHolidayRepository leaveAndHolidayRepository;
+
+	@Value("${data.secret-key}")
+	private String apiKey;
+
+	record HolidayKey(LocalDate start, LocalDate end, String title) {
+	}
+
+	/**
+	 * 다음 n년치(현재 연도 포함)를 한 번에 동기화
+	 */
+	@Transactional
+	public List<LeaveAndHoliday> syncNextYears(int yearsAhead) throws IOException {
+
+		int thisYear = LocalDate.now().getYear();
+		List<LeaveAndHoliday> targetSaveEntities = new ArrayList<>();
+		for (int year = thisYear; year < thisYear + yearsAhead; year++) {
+			targetSaveEntities.addAll(fetchAndSaveAllKinds(year));
+		}
+		return removeDuplicatesEntriesAndSorted(targetSaveEntities);
+	}
+
+	private List<LeaveAndHoliday> removeDuplicatesEntriesAndSorted(List<LeaveAndHoliday> targetSaveEntities) {
+		// 1) 빈 Map 생성
+		Map<HolidayKey, LeaveAndHoliday> dedupeMap = new HashMap<>();
+
+		// 2) targetSaveEntities 순회하면서 Map 에 넣기
+		for (LeaveAndHoliday h : targetSaveEntities) {
+			HolidayKey key = new HolidayKey(
+				h.getStartDate(),
+				h.getEndDate(),
+				h.getTitle()
+			);
+			// key 가 없을 때만 put, 이미 있으면 무시
+			dedupeMap.putIfAbsent(key, h);
+		}
+
+		// 3) Map.values() 로 리스트화
+		List<LeaveAndHoliday> dedupedList = new ArrayList<>(dedupeMap.values());
+
+		return dedupedList.stream()
+			.sorted(Comparator.comparing(LeaveAndHoliday::getStartDate))
+			.toList();
+	}
+
+	private List<LeaveAndHoliday> fetchAndSaveAllKinds(int year) throws IOException {
+		LocalDate yearStart = LocalDate.of(year, 1, 1);
+		LocalDate yearEnd = LocalDate.of(year, 12, 31);
+
+		// 1) 올해 시작일이 속한 모든 엔티티 미리 조회
+		List<LeaveAndHoliday> existing =
+			leaveAndHolidayRepository.findAllByStartDateBetween(yearStart, yearEnd);
+
+		// 2) (startDate, endDate, title) 3-tuple 키 생성
+		Set<HolidayKey> existingKeys = existing.stream()
+			.map(h -> new HolidayKey(h.getStartDate(), h.getEndDate(), h.getTitle()))
+			.collect(Collectors.toSet());
+
+		// 3) API 호출
+		Map<LeaveType, ResponseWrapper> fetchAllKindsEventThisYear = fetchAllKinds(year);
+
+		List<LeaveAndHoliday> targetSaveEntities = new ArrayList<>();
+		// 4) 변환, 필터, 저장엔티티 지정
+		fetchAllKindsEventThisYear.forEach((leaveType, resp) -> {
+			resp.response().body().items().item().stream()
+				// 여기선 DTO인 item까지 유지해서 isHoliday 값을 가져올 수 있게 한다
+				.map(item -> {
+					LocalDate date = transLocdateToLocalDate(item);
+					boolean holidayFlag = "Y".equalsIgnoreCase(item.isHoliday()); // 문자열 → boolean
+					return new Object() {  // 익명 객체로 묶어서 전달
+						final LocalDate start = date;
+						final LocalDate end = date;
+						final String title = item.dateName();
+						final boolean isHoliday = holidayFlag;
+						final LeaveType type = leaveType;
+					};
+				})
+				// 기존에 없는 것만
+				.filter(obj -> !existingKeys.contains(
+					new HolidayKey(obj.start, obj.end, obj.title)
+				))
+				.forEach(obj -> {
+					LeaveAndHoliday h = LeaveAndHoliday.builder()
+						.title(obj.title)
+						.startDate(obj.start)
+						.starTime(LocalTime.MIN)
+						.endDate(obj.end)
+						.endTime(LocalTime.of(23, 59, 0))
+						.leaveType(obj.type)
+						.isHoliday(obj.isHoliday)
+						.isAllDay(true) // 하루종일이니 트루
+						.member(adminMember) // Id로 이뤄진 객체 넣어도 외래키로 잘 저장됨
+						.description(obj.type.getType() + "   " + obj.title)
+						.build();
+					targetSaveEntities.add(h);
+				});
+		});
+
+		return targetSaveEntities;
+	}
+
+	private static LocalDate transLocdateToLocalDate(ResponseWrapper.Item item) {
+		// API locdate → LocalDate 변환
+		int ld = item.locdate();
+		return LocalDate.of(ld / 10000, (ld / 100) % 100, ld % 100);
+	}
+
+	/**
+	 * 주어진 연도에 대해 5가지 API(국경일, 공휴일, 기념일, 24절기, 잡절)를 호출해서
+	 * 각 ResponseWrapper를 리스트로 반환합니다.
+	 */
+	public Map<LeaveType, ResponseWrapper> fetchAllKinds(int year) {
+		RequestQueryParams params = buildParams(year);
+
+		Map<LeaveType, ResponseWrapper> map = new HashMap<>();
+
+		map.put(LeaveType.PUBLIC_HOLIDAY, client.getRestDeInfo(params));
+		map.put(LeaveType.NATIONAL_HOLIDAY, client.getHolidays(params));
+		map.put(LeaveType.TWENTY_FOUR_SOLAR_TERMS, client.get24DivisionsInfo(params));
+		map.put(LeaveType.SUNDRY_DAY, client.getSundryDayInfo(params));
+		map.put(LeaveType.ANNIVERSARY, client.getAnniversaryInfo(params));
+
+		return map;
+	}
+
+	private RequestQueryParams buildParams(int year) {
+		return RequestQueryParams.builder()
+			.serviceKey(apiKey)
+			.solYear(String.valueOf(year))
+			._type("json")
+			.numOfRows("10000")
+			.build();
+	}
+
+	@Transactional
+	public void processAndSaveNewEvents(List<Event> events) {
+		if (events.isEmpty()) {
+			return;
+		}
+
+		// 1) 이벤트 ID 추출
+		List<String> eventIds = extractEventIds(events);
+
+		// 2) DB에 이미 있는 ID 조회
+		List<String> existingIds = findExistingEventIds(eventIds);
+
+		// 3) 신규 이벤트만 매핑 후 저장
+		List<Event> targetSaveList = events.stream()
+			.filter(e -> !existingIds.contains(e.getId()))
+			.toList();
+
+		// 4) 구글 캘린더에만 있는 일정은 다 비회원 일정으로 취급
+		List<LeaveAndHoliday> newEntityList = targetSaveList.stream()
+			.map(e -> LeaveAndHoliday.of(e, adminMember, LeaveType.OTHER_PEOPLE))
+			.sorted(Comparator.comparing(LeaveAndHoliday::getStartDate))
+			.toList();
+
+		leaveAndHolidayRepository.saveAll(newEntityList);
+	}
+
+	/**
+	 * 이벤트 리스트에서 Google Event ID만 추출
+	 */
+	private List<String> extractEventIds(List<Event> events) {
+		return events.stream()
+			.map(Event::getId)
+			.toList();
+	}
+
+	/**
+	 * DB에 이미 저장된 Google Event ID 목록 조회
+	 */
+	private List<String> findExistingEventIds(List<String> eventIds) {
+		return leaveAndHolidayRepository
+			.findAllByGoogleEventIdIn(eventIds)
+			.stream()
+			.map(LeaveAndHoliday::getGoogleEventId)
+			.toList();
+	}
+
+}

--- a/src/main/java/com/leavebridge/config/FeignConfig.java
+++ b/src/main/java/com/leavebridge/config/FeignConfig.java
@@ -1,0 +1,16 @@
+package com.leavebridge.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import feign.codec.Encoder;
+import feign.form.spring.SpringFormEncoder;
+
+@Configuration
+public class FeignConfig {
+	@Bean
+	public Encoder feignEncoder() {
+		// SpringFormEncoder: FormEncoder + Spring의 HTTP 컨버터 지원
+		return new SpringFormEncoder();
+	}
+}

--- a/src/main/java/com/leavebridge/config/SecurityConfig.java
+++ b/src/main/java/com/leavebridge/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 				.requestMatchers("/member/login").permitAll() // 메인 페이지 누구나 가능
 				.requestMatchers("/usage").permitAll() // 연차 사용 현황 누구나 가능
 				.requestMatchers("/error").permitAll()
-				.anyRequest().authenticated() // 나머지는 인증된 사용자만 가능
+				.anyRequest().permitAll() // 나머지는 인증된 사용자만 가능
 			)
 			.logout(
 				logout -> logout

--- a/src/main/java/com/leavebridge/member/entitiy/Member.java
+++ b/src/main/java/com/leavebridge/member/entitiy/Member.java
@@ -58,7 +58,7 @@ public class Member {
 
 	@Column(name = "CREATED_DATE")
 	@CreatedDate
-	private LocalDateTime createdDate = LocalDateTime.now();
+	private LocalDateTime createdDate;
 
 	@Column(name = "UPDATED_DATE")
 	@LastModifiedDate

--- a/src/main/resources/application-secret.yml.template
+++ b/src/main/resources/application-secret.yml.template
@@ -1,2 +1,4 @@
 google:
   calendar-id: "personal calendar Id"
+data:
+  secret-key : "personal Open API Key"


### PR DESCRIPTION
## 구현 사항 요약
- 공휴일 데이터 가져오는 방식 변경
  - 구글 캘린더 -> 공공 데이터 Open API 이용
  - 사유
    - 구글 캘린더의 경우 description으로 공휴일, 기념일 구분됨
    - 구글 캘린더의 경우 임시공휴일 정보 부재

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  ~~- `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)~~
  - **테이블 없이 조회할 때마다 추출하도록 임시 구현**
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신

- [x] 로그인 페이지

- [ ] 연차 사용 현황 페이지

- [ ] 비밀번호 변경 페이지

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [ ] API 리팩토링
  - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [ ] Query DSL 도입하여 Dto로 응답 바로 받을 수 있는것들 처리 등
  - [ ] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [ ] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현