### PR TITLE
비밀번호 변경 기능 구현 & 관리자가 휴일 등록 가능하도록

### DIFF
--- a/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
@@ -23,9 +23,10 @@ public record CreateLeaveRequestDto(
 	LocalTime startTime,
 	@Schema(description = "종료 날짜 시간", example = "23:59")
 	LocalTime endTime,
-
 	@Schema(description = "비고", example = "일정 설명 텍스트")
-	String description
+	String description,
+	@Schema(description = "휴일 포함 여부", example = "true(휴일 포함), false(휴일 미포함)")
+	Boolean isHolidayInclude
 ) {
 	public CreateLeaveRequestDto {
 		if (!Boolean.TRUE.equals(isAllDay)) {

--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
@@ -23,7 +23,10 @@ public record MonthlyEvent(
 	LocalDateTime end,
 
 	@Schema(description = "하루 종일 일정인지", example = "true or false")
-	boolean allDay
+	boolean allDay,
+
+	@Schema(description = "휴일인지 여부", example = "true or false")
+	Boolean isHoliday
 ) {
 	public static MonthlyEvent from(LeaveAndHoliday leaveAndHoliday) {
 		return MonthlyEvent.builder()
@@ -32,6 +35,7 @@ public record MonthlyEvent(
 			.start(LocalDateTime.of(leaveAndHoliday.getStartDate(), leaveAndHoliday.getStarTime()))
 			.end(LocalDateTime.of(leaveAndHoliday.getEndDate(), leaveAndHoliday.getEndTime()))
 			.allDay(leaveAndHoliday.getIsAllDay())
+			.isHoliday(leaveAndHoliday.getIsHoliday())
 			.build();
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
@@ -25,7 +25,9 @@ public record MonthlyEventDetailResponse(
 	@Schema(description = "일정 상세 설명", example = "일정 설명 텍스트")
 	String description,
 	@Schema(description = "일정 수정, 삭제 가능한지 여부", example = "true(수정 가능), false(수정 불가)")
-	Boolean isOwner
+	Boolean isOwner,
+	@Schema(description = "휴일 여부", example = "true (휴일), false(휴일 아님)")
+	Boolean isHoliday
 ) {
 	public static MonthlyEventDetailResponse of(LeaveAndHoliday leaveAndHoliday, Boolean isOwer) {
 		return MonthlyEventDetailResponse.builder()
@@ -37,6 +39,7 @@ public record MonthlyEventDetailResponse(
 			.leaveType(leaveAndHoliday.getLeaveType())
 			.description(leaveAndHoliday.getDescription())
 			.isOwner(isOwer)
+			.isHoliday(leaveAndHoliday.getIsHoliday())
 			.build();
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
@@ -26,7 +26,9 @@ public record PatchLeaveRequestDto(
 	@Schema(description = "수정 종료 날짜 시간", example = "23:59")
 	LocalTime endTime,
 	@Schema(description = "수정 비고", example = "일정 설명 수정 텍스트")
-	String description
+	String description,
+	@Schema(description = "수정 휴일 포함 여부", example = "true(휴일 포함), false(휴일 미포함)")
+	Boolean isHolidayInclude
 ) {
 	public PatchLeaveRequestDto {
 		if (!Boolean.TRUE.equals(isAllDay)) {

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -182,4 +182,8 @@ public class LeaveAndHoliday {
 	public boolean canModifyLeave(){
 		return !leaveType.equals(LeaveType.PUBLIC_HOLIDAY) && !leaveType.equals(LeaveType.OTHER_PEOPLE);
 	}
+
+	public void updateIsHoliday(Boolean isHoliday) {
+		this.isHoliday = Boolean.TRUE.equals(isHoliday);
+	}
 }

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -7,7 +7,6 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 
-import com.google.api.services.calendar.model.Events;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -113,6 +112,7 @@ public class CalendarService {
 
 		try {
 			LeaveAndHoliday entity = LeaveAndHoliday.of(requestDto, member, created.getId());
+			entity.updateIsHoliday(requestDto.isHolidayInclude()); // 휴가 포함인지 여부
 			leaveAndHolidayRepository.saveAndFlush(entity);
 		} catch (RuntimeException dbException) {
 			// 캘린더에 저장된거 삭제
@@ -142,6 +142,7 @@ public class CalendarService {
 
 		// 1) 엔티티 수정
 		leaveAndHoliday.patchEntityByDto(dto);
+		leaveAndHoliday.updateIsHoliday(dto.isHolidayInclude()); // 휴가 포함인지 여부
 
 		String googleEventId = leaveAndHoliday.getGoogleEventId();
 

--- a/src/main/java/com/leavebridge/member/controller/MemberController.java
+++ b/src/main/java/com/leavebridge/member/controller/MemberController.java
@@ -3,13 +3,19 @@ package com.leavebridge.member.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.leavebridge.member.dto.MemberUsedLeavesResponseDto;
+import com.leavebridge.member.dto.RequestChangePasswordRequest;
+import com.leavebridge.member.entitiy.CustomMemberDetails;
 import com.leavebridge.member.service.MemberService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,5 +30,14 @@ public class MemberController {
 	@GetMapping("/used-leaves")
 	public ResponseEntity<List<MemberUsedLeavesResponseDto>> getUsedLeaves() {
 		return ResponseEntity.ok(memberService.getMemberUsedLeaves());
+	}
+
+	@PostMapping("/change-passwords")
+	public ResponseEntity<Void> changePassword(
+		@RequestBody @Valid RequestChangePasswordRequest requestChangePasswordRequest,
+		@AuthenticationPrincipal CustomMemberDetails customMemberDetails) {
+		log.info("MemberController :: changePassword memberId = {}", customMemberDetails.getUsername());
+		memberService.changePassword(customMemberDetails.getMember(), requestChangePasswordRequest);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/leavebridge/member/dto/RequestChangePasswordRequest.java
+++ b/src/main/java/com/leavebridge/member/dto/RequestChangePasswordRequest.java
@@ -1,0 +1,18 @@
+package com.leavebridge.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RequestChangePasswordRequest(
+	@Schema(description = "현재 비밀번호", example = "currentPassword123!")
+	@NotBlank(message = "현재 비밀번호를 입력하세요")
+	String currentPassword,
+
+	@Schema(description = "새 비밀번호", example = "newPassword456!")
+	@NotBlank(message = "새 비밀번호를 입력하세요")
+	String newPassword,
+
+	@Schema(description = "비밀번호 확인", example = "newPassword456!")
+	@NotBlank(message = "비밀번호 확인을 입력하세요")
+	String confirmPassword
+) { }

--- a/src/main/java/com/leavebridge/member/entitiy/Member.java
+++ b/src/main/java/com/leavebridge/member/entitiy/Member.java
@@ -77,4 +77,8 @@ public class Member {
 	public boolean isAdmin() {
 		return this.memberRole == MemberRole.ROLE_ADMIN;
 	}
+
+	public void updatePassword(String encodedPassword) {
+		this.password = encodedPassword;
+	}
 }

--- a/src/main/java/com/leavebridge/member/entitiy/Member.java
+++ b/src/main/java/com/leavebridge/member/entitiy/Member.java
@@ -75,6 +75,6 @@ public class Member {
 	}
 
 	public boolean isAdmin() {
-		return this.memberRole == MemberRole.ADMIN;
+		return this.memberRole == MemberRole.ROLE_ADMIN;
 	}
 }

--- a/src/main/java/com/leavebridge/member/entitiy/MemberRole.java
+++ b/src/main/java/com/leavebridge/member/entitiy/MemberRole.java
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum MemberRole implements GrantedAuthority {
 
-	MEMBER("일반 회원"),
-	ADMIN("관리자");
+	ROLE_MEMBER("일반 회원"),
+	ROLE_ADMIN("관리자");
 
 	private final String description;
 

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -31,12 +31,25 @@
                                required>
                     </div>
 
-                    <!-- 종일 체크박스 -->
-                    <div class="form-check mb-3">
-                        <input class="form-check-input" type="checkbox" id="allDayCheck" name="isAllDay" value="true">
-                        <label class="form-check-label" for="allDayCheck">
-                            하루 종일 여부(All Day)
-                        </label>
+                    <!-- 종일+휴일 포함 체크박스 그룹 -->
+                    <div class="d-flex align-items-center mb-3">
+                        <!-- allDay -->
+                        <div class="form-check form-check-inline me-3 mb-0">
+                            <input class="form-check-input" type="checkbox"
+                                   id="allDayCheck" name="isAllDay" value="true">
+                            <label class="form-check-label" for="allDayCheck">
+                                하루 종일 여부(All Day)
+                            </label>
+                        </div>
+                        <!-- holidayInclude (관리자만) -->
+                        <div class="form-check form-check-inline mb-0"
+                             sec:authorize="hasRole('ADMIN')">
+                            <input class="form-check-input" type="checkbox"
+                                   id="holidayIncludeCheck" name="isHolidayInclude" value="true">
+                            <label class="form-check-label" for="holidayIncludeCheck">
+                                휴일 포함 여부
+                            </label>
+                        </div>
                     </div>
 
                     <div class="mb-3">
@@ -50,9 +63,14 @@
                             <option value="SUMMER_VACATION">여름휴가</option>
                             <option value="NON_DEDUCTIBLE">비차감 휴가(공가)</option>
                             <option value="MEETING">회의</option>
+                            <option sec:authorize="hasRole('ADMIN')" value="PUBLIC_HOLIDAY">공휴일</option>
+                            <option sec:authorize="hasRole('ADMIN')" value="ANNIVERSARY">기념일</option>
                         </select>
                         <div class="form-text fw-bold">
                             한 번에 하나의 연차 타입만 등록 가능합니다. 다른 타입은 별도 등록해 주세요.
+                        </div>
+                        <div class="form-text fw-bold" sec:authorize="hasRole('ADMIN')" id="holidayNotice" style="display: none;">
+                            휴일 포함 체크시 해당 기간동안 연차 등록이 불가능합니다.
                         </div>
                     </div>
 
@@ -127,7 +145,17 @@
                                 <dt class="col-sm-3">
                                     <i class="bi bi-card-text me-1"></i>설명
                                 </dt>
-                                <dd id="modalDescription" class="col-sm-9">세부 일정 및 준비물</dd>
+                                <dd id="modalDescription" class="col-sm-9">설명 없음</dd>
+
+                                <!-- 휴일 표시: isHoliday가 true일 때만 -->
+                                <dt class="col-sm-3" id="modalHolidayLabel" style="display:none">
+                                    <i class="bi bi-calendar-event-fill me-1"></i>휴일
+                                </dt>
+                                <dd class="col-sm-9" id="modalHolidayInfo" style="display:none">
+                                    <!-- allDay일 때와 아닐 때 구분 -->
+                                    <span id="modalHolidayText"></span>
+                                </dd>
+
                             </dl>
                         </div>
                     </div>
@@ -257,7 +285,14 @@
             const modalDeleteBtn = document.getElementById('modalDeleteBtn');
             const deleteConfirmModal = new bootstrap.Modal(document.getElementById('deleteConfirmModal'));
             const confirmDeleteBtn = document.getElementById('confirmDeleteBtn');
+            const allDayCheck         = document.getElementById('allDayCheck');
+            const holidayIncludeCheck = document.getElementById('holidayIncludeCheck');
+            const holidayIncludeGroup = holidayIncludeCheck?.closest('.form-check');
+            const holidayNotice = document.getElementById('holidayNotice');
 
+            if (holidayIncludeGroup) {
+                holidayIncludeGroup.style.display = 'none';
+            }
             let currentEventId = null;  // 수정 중인 이벤트 ID 보관
 
             allDayCheck.addEventListener('change', onModifyToggleAllDayChange);
@@ -283,8 +318,20 @@
 
             // 3) leaveType 변경 시 UI 조정
             function onLeaveTypeChange() {
+                const isHoliday = ['PUBLIC_HOLIDAY','ANNIVERSARY'].includes(leaveTypeEl.value);
                 const currentType = leaveTypeEl.value;
 
+                // holidayIncludeCheck 요소가 실제로 존재할 때만 동작
+                if (typeof holidayIncludeCheck !== 'undefined' && holidayIncludeCheck !== null) {
+                    // 1) 공휴일/기념일일 때만 보이기
+                    holidayIncludeGroup.style.display = isHoliday ? '' : 'none';
+                    holidayNotice.style.display = isHoliday ? '' : 'none';
+
+                    // 2) 공휴일이 아니면 체크 해제
+                    if (!isHoliday) {
+                        holidayIncludeCheck.checked = false;
+                    }
+                }
                 // 0) 기본 리셋 (페어된 로직만 남김)
                 allDayCheck.disabled = false;
                 startTimeEl.required = false;
@@ -368,7 +415,6 @@
                         break;
 
                     case 'NON_DEDUCTIBLE':
-                        // 범위만 공통 적용, 나머지 기본 동작 유지
                         descriptionEl.required = true
                         break;
 
@@ -382,6 +428,7 @@
             }
 
             leaveTypeEl.addEventListener('change', onLeaveTypeChange);
+
 
             // “수정” 버튼 클릭 핸들러
             modalEditBtn.addEventListener('click', (e) => {
@@ -477,12 +524,32 @@
                     const y = midDate.getFullYear();      // 예: 2025
                     const m = midDate.getMonth() + 1;     // 1~12
 
-                    // GET 요청 → Promise 반환
                     return fetch(`/api/v1/calendar/events/${y}/${m}`)
                         .then(res => {
                             if (!res.ok) throw new Error('네트워크 에러');
-                            return res.json();                // JSON 배열을 반환하는 Promise
-                        });
+                            return res.json();
+                        })
+                        .then(events => {
+                            // events 는 MonthlyEvent DTO 배열이라고 가정
+                            return events.map(evt => ({
+                                id:             evt.id,
+                                title:          evt.title,
+                                start:          evt.start,
+                                end:            evt.end,
+                                allDay:         evt.allDay,
+                                // isHoliday 플래그에 따라 색상 지정
+                                backgroundColor: evt.isHoliday ? '#dc3545' : undefined,
+                                borderColor:     evt.isHoliday ? '#dc3545' : undefined,
+                                textColor:       evt.isHoliday ? '#ffffff' : undefined,
+                            }));
+                            successCallback(fcEvents);
+                        })
+                        .catch(err => {
+                            console.error(err);
+                            showToast('일정을 불러오는 중 오류가 발생했습니다.', 'error');
+                            // 실패 콜백에 빈 배열을 넘겨줘서 캘린더가 비어 있게 함
+                            failureCallback([]);
+                        });;
                 },
 
                 // event 클릭 함수 정의 -> 일정 정보 (수정, 삭제 가능하도록)
@@ -515,6 +582,24 @@
                                 modalDeleteBtn.style.display = 'none';
                             }
 
+                            // 휴일 라벨·정보 토글
+                            const isHoliday = data.isHoliday;
+                            document.getElementById('modalHolidayLabel').style.display = isHoliday ? '' : 'none';
+                            document.getElementById('modalHolidayInfo' ).style.display = isHoliday ? '' : 'none';
+
+                            if (isHoliday) {
+                                let text;
+                                if (data.isAllDay) {
+                                    // DTO의 isAllDay 플래그 활용
+                                    text = '종일';
+                                } else {
+                                    // DTO의 startTime, endTime을 바로 포맷
+                                    const fmt = t => t.padStart(5, '0'); // "9:0" → "09:00"
+                                    text = `${fmt(data.startTime)} ~ ${fmt(data.endTime)}`;
+                                }
+                                document.getElementById('modalHolidayText').textContent = text;
+                            }
+
                             // Bootstrap 모달 표시
                             detailEventModal.show();
                         })
@@ -531,6 +616,13 @@
                         showToast('일정 등록은 로그인 후 가능합니다.', 'warning');
                         return;
                     }
+
+                    // const day = info.date.getDay();
+                    // // 일요일(0) 또는 토요일(6) 이면
+                    // if (day === 0 || day === 6) {
+                    //     showToast('주말은 일정 등록할 수 없습니다.', 'warning');
+                    //     return;
+                    // }
                     // 등록 모드 진입 시 기존 ID 초기화
                     currentEventId = null;
                     // 전역 변수에 클릭한 날짜 저장
@@ -621,6 +713,11 @@
 
                 // 2) allDay 키가 없으면 기본 false 주입 (문자열 → boolean 변환 포함)
                 dataObj.isAllDay = document.getElementById('allDayCheck').checked; // true / false
+
+                // holidayInclude도 boolean값 전달
+                if (typeof holidayIncludeCheck !== 'undefined' && holidayIncludeCheck !== null) {
+                    dataObj.isHolidayInclude = holidayIncludeCheck.checked;
+                }
 
                 // 2) 등록 버튼 비활성화
                 submitBtn.disabled = true;

--- a/src/main/resources/templates/member/change_password.html
+++ b/src/main/resources/templates/member/change_password.html
@@ -6,14 +6,7 @@
 <div layout:fragment="content">
     <div class="w-100" style="max-width:400px;">
         <h3 class="mb-4 text-center">비밀번호 변경</h3>
-        <form id="changePwdForm" th:action="@{/member/change-password}" method="post">
-            <!-- 변경 실패 시 에러 표시 -->
-            <div th:if="${param.error}">
-                <div class="alert alert-danger">
-                    비밀번호 변경에 실패했습니다. 입력값을 확인해 주세요.
-                </div>
-            </div>
-
+        <form id="changePwdForm" method="post">
             <div class="mb-3">
                 <label for="currentPassword" class="form-label">현재 비밀번호</label>
                 <input type="password"
@@ -46,7 +39,6 @@
             </button>
         </form>
     </div>
-</div>
 
 <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -54,28 +46,38 @@
         form.addEventListener('submit', async (e) => {
             e.preventDefault();  // 기본 폼 전송 막기
 
-            const formData = new FormData(form);
-            const data = Object.fromEntries(formData.entries());
+            // 1) 입력 데이터 추출
+            const data = {
+                currentPassword: form.currentPassword.value,
+                newPassword:     form.newPassword.value,
+                confirmPassword: form.confirmPassword.value
+            };
 
             try {
-                const res = await fetch(form.action, {
+                const res = await fetch('/api/v1/member/change-passwords', {
                     method: form.method.toUpperCase(), // "POST"
                     headers: requestHeaders,
                     body: JSON.stringify(data)
                 });
 
-                if (!res.ok) throw new Error('서버 오류');
-
-                // 성공 시 confirm 창
-                if (confirm('비밀번호가 성공적으로 변경되었습니다.\n홈으로 이동하시겠습니까?')) {
-                    window.location.href = '/';
+                if (!res.ok) {
+                    // 에러 메시지 파싱(필요 시)
+                    const err = await res.json().catch(() => null);
+                    const msg = err?.message || '비밀번호 변경에 실패했습니다.';
+                    showToast(msg, 'error');
+                    return;
                 }
+
+                showToast('비밀번호가 변경되었습니다.', 'success');
+                // 1초 뒤 홈으로 이동
+                setTimeout(() => window.location.href = '/', 1000);
 
             } catch (err) {
                 console.error(err);
-                alert('비밀번호 변경에 실패했습니다.');
+                showToast('서버 요청 중 오류가 발생했습니다.', 'error');
             }
         });
     });
 </script>
+</div>
 </html>


### PR DESCRIPTION
## 구현 사항 요약
- 일정 목록 보여질때 휴일의 경우 빨간색으로 보이도록
- 관리자가 공휴일, 기념일 등록할 수 있도록
- 비밀번호 변경 기능 구현
- 일정 상세에서 휴일 여부 표기

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장
  - [x] `MEMBER` : 사용자 정보 저장
  ~~- `temp` : 사용자별 연차 사용 현황 (고민중, 매번 계산하면 무거워지지 않을까 싶어 별도 테이블 도입)~~
  - **테이블 없이 조회할 때마다 추출하도록 임시 구현**
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신

- [x] 로그인 페이지

- [ ] 연차 사용 현황 페이지

- [x] 비밀번호 변경 페이지
- [x] 비밀번호 변경 API

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [ ] API 리팩토링
  - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [ ] Query DSL 도입하여 Dto로 응답 바로 받을 수 있는것들 처리 등
  - [ ] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [ ] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현