### PR TITLE
휴일 등록할 시 해당 기간 내 포함하는 기존 연차 삭제 & 차감 시간 조정

### DIFF
--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEvent.java
@@ -1,6 +1,8 @@
 package com.leavebridge.calendar.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
 
@@ -29,12 +31,25 @@ public record MonthlyEvent(
 	Boolean isHoliday
 ) {
 	public static MonthlyEvent from(LeaveAndHoliday leaveAndHoliday) {
+		LocalDate startDate = leaveAndHoliday.getStartDate();
+		LocalTime startTime = leaveAndHoliday.getStarTime();
+		LocalDate endDate   = leaveAndHoliday.getEndDate();
+		LocalTime endTime   = leaveAndHoliday.getEndTime();
+		boolean allDay      = Boolean.TRUE.equals(leaveAndHoliday.getIsAllDay());
+
+		LocalDateTime start = LocalDateTime.of(startDate, startTime);
+		LocalDateTime end = LocalDateTime.of(endDate, endTime);
+		if (allDay) {
+			// all-day 이벤트는 end 날짜를 exclusive 처리하기 위해 +1일
+			end = LocalDateTime.of(endDate.plusDays(1), LocalTime.MIDNIGHT);
+		}
+
 		return MonthlyEvent.builder()
 			.id(leaveAndHoliday.getId())
 			.title(leaveAndHoliday.getTitle())
-			.start(LocalDateTime.of(leaveAndHoliday.getStartDate(), leaveAndHoliday.getStarTime()))
-			.end(LocalDateTime.of(leaveAndHoliday.getEndDate(), leaveAndHoliday.getEndTime()))
-			.allDay(leaveAndHoliday.getIsAllDay())
+			.start(start)
+			.end(end)
+			.allDay(allDay)
 			.isHoliday(leaveAndHoliday.getIsHoliday())
 			.build();
 	}

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -43,8 +43,11 @@ import lombok.ToString;
 @EntityListeners(AuditingEntityListener.class)
 public class LeaveAndHoliday {
 
+	// 상수들 모아두기
 	public static final LocalTime WORK_START_TIME = LocalTime.of(8, 0);
 	public static final LocalTime WORK_END_TIME = LocalTime.of(17, 0);
+	public static final LocalTime LUNCH_START = LocalTime.NOON;        // 12:00
+	public static final LocalTime LUNCH_END = LocalTime.of(13, 0);   // 13:00
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -95,6 +98,12 @@ public class LeaveAndHoliday {
 
 	@Column(name = "IS_HOLIDAY")
 	private Boolean isHoliday;
+
+	@Column(name = "USED_LEAVE_HOURS")
+	private Double usedLeaveHours;  // 차감 연차 시간
+
+	@Column(name = "COMMENT")
+	private String comment;  // 연차 미차감 사유
 
 	public static LeaveAndHoliday of(Event event, Member member, LeaveType leaveType) {
 
@@ -185,5 +194,13 @@ public class LeaveAndHoliday {
 
 	public void updateIsHoliday(Boolean isHoliday) {
 		this.isHoliday = Boolean.TRUE.equals(isHoliday);
+	}
+
+	public void updateUsedLeaveHours(Double usedLeaveHours) {
+		this.usedLeaveHours = usedLeaveHours;
+	}
+
+	public void updateComment(String comment) {
+		this.comment = comment;
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
+++ b/src/main/java/com/leavebridge/calendar/enums/LeaveType.java
@@ -34,4 +34,8 @@ public enum LeaveType {
 
 	private final String type;
 	private final boolean isDeductible;  // true면 연차 소진
+
+	public boolean isConsumesLeave() {
+		return this.isDeductible;
+	}
 }

--- a/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
+++ b/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
@@ -4,13 +4,33 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
+import com.leavebridge.calendar.enums.LeaveType;
 
 @Repository
 public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday, Long> {
 	List<LeaveAndHoliday> findAllByGoogleEventIdIn(List<String> eventIds);
 	List<LeaveAndHoliday> findAllByStartDateGreaterThanEqualAndStartDateLessThan(LocalDate start, LocalDate end);
 	List<LeaveAndHoliday> findAllByStartDateBetween(LocalDate yearStart, LocalDate yearEnd);
+
+	boolean existsByStartDateAndIsHolidayTrueAndIsAllDayTrue(LocalDate start);
+
+	List<LeaveAndHoliday> findByStartDateAndIsHolidayTrueAndIsAllDayFalse(LocalDate startDate);
+
+	@Query("""
+		   SELECT l FROM LeaveAndHoliday l
+		WHERE (l.isHoliday = false OR l.isHoliday IS NULL)
+		      AND l.leaveType IN :consumesLeaveTypes
+		      AND l.startDate <= :holidayEnd
+		      AND l.endDate   >= :holidayStart
+		""")
+	List<LeaveAndHoliday> findAllConsumesLeaveByDateRange(
+		@Param("holidayStart") LocalDate holidayStart,
+		@Param("holidayEnd")   LocalDate holidayEnd,
+		@Param("consumesLeaveTypes") List<LeaveType> consumesLeaveTypes
+	);
 }

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -1,11 +1,17 @@
 package com.leavebridge.calendar.service;
 
+import static com.leavebridge.calendar.entity.LeaveAndHoliday.*;
+
 import java.io.IOException;
+import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -50,17 +56,15 @@ public class CalendarService {
 
 		LeaveAndHoliday leaveAndHoliday = leaveAndHolidayRepository.findById(eventId).orElseThrow(
 			() -> new IllegalArgumentException("존재하지 않는 일정 Id입니다."));
-
 		boolean canAccess = checkOwnerOrAdminMember(member, leaveAndHoliday);
 		boolean cantModifyLeave = leaveAndHoliday.canModifyLeave();
-
 		return MonthlyEventDetailResponse.of(leaveAndHoliday, canAccess && cantModifyLeave);
 	}
 
 	/**
 	 * 지정된 calendarId의 설정한 연도, 월에 해당하는 일정 목록 로드
 	 */
-	public List<MonthlyEvent> listMonthlyEvents(int year, int month) throws Exception {
+	public List<MonthlyEvent> listMonthlyEvents(int year, int month) {
 		log.info("CalendarService.listMonthlyEvents :: year={}, month={}", year, month);
 
 		LocalDate startDate = LocalDate.of(year, month, 1);
@@ -80,52 +84,307 @@ public class CalendarService {
 	 */
 	@Transactional
 	public void createTimedEvent(CreateLeaveRequestDto requestDto, Member member) throws IOException {
-		// 1) Event 객체 생성 및 기본 정보 설정
-		Event event = new Event().setSummary(requestDto.title());
+		// 휴일인 경우
+		if (Boolean.TRUE.equals(requestDto.isHolidayInclude())) {
+			handleHolidayRegistration(requestDto, member);
+		}
+		// 휴일 아닌 경우
+		else {
+			handleLeaveRegistration(requestDto, member);
+		}
+	}
 
-		LocalDateTime startLdt = DateUtils.makeLocalDateTimeFromLocalDAteAndLocalTime(
-			requestDto.startDate(), requestDto.startTime());
+	/**
+	 * 휴일 등록 - 등록한 휴일에 기존 일정이 있을경우 삭제 (연차 차감되는 일정들만)
+	 */
 
-		LocalDateTime endLdt = DateUtils.makeLocalDateTimeFromLocalDAteAndLocalTime(
-			requestDto.endDate(), requestDto.endTime());
-
-		// 3) 구글 캘린더에 보낼 start/end 설정
-		if (requestDto.isAllDay()) {
-			// 날짜 전용 (종일 이벤트)
-			event.setStart(new EventDateTime().setDate(new DateTime(requestDto.startDate().toString())));
-			// 종료는 “다음 날” 날짜만 넘김
-			event.setEnd(new EventDateTime().setDate(new DateTime(requestDto.endDate().plusDays(1).toString())));
-		} else {
-			// 시간 지정
-			DateTime startDt = new DateTime(Date.from(
-				startLdt.atZone(ZoneId.of(DEFAULT_TIME_ZONE)).toInstant()));
-			DateTime endDt = new DateTime(Date.from(
-				endLdt.atZone(ZoneId.of(DEFAULT_TIME_ZONE)).toInstant()));
-			event.setStart(new EventDateTime().setDateTime(startDt));
-			event.setEnd(new EventDateTime().setDateTime(endDt));
+	private void handleHolidayRegistration(CreateLeaveRequestDto dto, Member member) throws IOException {
+		if(!member.isAdmin()) {
+			log.info("비관리자의 휴일 등록 시도 차단 loginId = {}", member.getLoginId());
+			throw new IllegalArgumentException("관리자만 휴일 등록이 가능합니다.");
+		}
+		// 1. 캘린더 등록
+		Event event = createCalendarEvent(dto);
+		Event created;
+		try {
+			created = calendarClient.events().insert(GOOGLE_PERSONAL_CALENDAR_ID, event).execute();
+		}
+		catch (Exception dbEx) {
+			log.info("일정 등록 실패");
+			throw new IllegalArgumentException("일정 등록 실패");
 		}
 
-		// 4) Calendar API 호출하여 등록
-		Event created = calendarClient.events()
-			.insert(GOOGLE_PERSONAL_CALENDAR_ID, event)
+		// 2. DB 저장
+		try {
+			saveEntity(dto, member, created.getId(), dto.isHolidayInclude(), 0.0, null);
+		} catch (Exception e) {
+			rollbackCalendar(created.getId());
+			throw e;
+		}
+		// 3. 기존 연차 보정
+		adjustOverlappingLeaves(dto);
+	}
+
+	/**
+	 * 일정 등록 - 일반 일정 등록
+	 * 중간에 휴일있을 경우 사용 시간 계산 제외, 휴일 또는 주말 시작일 불가능
+	 */
+	private void handleLeaveRegistration(CreateLeaveRequestDto requestDto, Member member) throws IOException {
+		double usedDays = 0.0;
+		String comment = null;
+
+		// 1) “연차 소진” 타입인 경우에만 검증 & 연차 사용 처리
+		if (requestDto.leaveType().isConsumesLeave()) {
+			// 1-1. 검증(주말 혹은 휴일에 쓰려는거 아닌지)
+			validateLeave(requestDto);
+
+			// 1-2. 연차 사용 시간 계산 (0.0 ~ N.0)
+			Map<String, Object> usedInfoMap = calcUsedDaysAndGetComment(requestDto.startDate(), requestDto.startTime(),
+				requestDto.endDate(), requestDto.endTime());
+			usedDays = (double)usedInfoMap.get("usedDays");
+			comment = (String)usedInfoMap.get("comment");
+
+			if (usedDays == 0.0) {
+				throw new IllegalArgumentException("해당 기간에 소진되는 연차가 없어 등록할 수 없습니다.");
+			}
+		}
+
+		// 2) Google Calendar 이벤트 생성 (소진 여부와 무관하게)
+		Event leaveEvent = createCalendarEvent(requestDto);
+		Event createdLeave = calendarClient.events()
+			.insert(GOOGLE_PERSONAL_CALENDAR_ID, leaveEvent)
 			.execute();
 
+		// 3. DB 저장
 		try {
-			LeaveAndHoliday entity = LeaveAndHoliday.of(requestDto, member, created.getId());
-			entity.updateIsHoliday(requestDto.isHolidayInclude()); // 휴가 포함인지 여부
-			leaveAndHolidayRepository.saveAndFlush(entity);
-		} catch (RuntimeException dbException) {
-			// 캘린더에 저장된거 삭제
-			try {
-				calendarClient.events()
-					.delete(GOOGLE_PERSONAL_CALENDAR_ID, event.getId())
-					.execute();
-			} catch (Exception ignore) {
-				log.error("Calendar에 저장 성공했으나 DB 저장 실패하여 캘린더 삭제 시도했으나 삭제 실패, 수동 업데이트 필요 event = {}", event);
-			}
-			// db 예외난거는 다시 롤백하기 위해서 예외 다시 던짐
-			throw dbException;
+			// 일반 사용자
+			saveEntity(requestDto, member, createdLeave.getId(), false, usedDays, comment);
+		} catch (Exception e) {
+			rollbackCalendar(createdLeave.getId());
+			throw e;
 		}
+	}
+
+	private void adjustOverlappingLeaves(CreateLeaveRequestDto dto) throws IOException {
+		// 휴일 범위
+		LocalDate holStartDate = dto.startDate();
+		LocalTime holStartTime = dto.startTime();
+		LocalDate holEndDate   = dto.endDate();
+		LocalTime holEndTime   = dto.endTime();
+
+		// 연차 소진 타입 이벤트 조회
+		List<LeaveAndHoliday> list = leaveAndHolidayRepository.findAllConsumesLeaveByDateRange(
+			holStartDate, holEndDate,
+			List.of(LeaveType.FULL_DAY_LEAVE, LeaveType.HALF_DAY_MORNING,
+				LeaveType.HALF_DAY_AFTERNOON, LeaveType.OUTING, LeaveType.SUMMER_VACATION)
+		);
+
+		for (LeaveAndHoliday leave : list) {
+			LocalDate leaveStartDate = leave.getStartDate();
+			LocalDate leaveEndDate   = leave.getEndDate();
+			LocalTime leaveStartTime = leave.getStarTime();
+			LocalTime leaveEndTime   = leave.getEndTime();
+
+			// 각 날짜별로 휴일 범위에 완전 포함되는지 확인
+			boolean fullyCovered = true;
+			for (LocalDate d = leaveStartDate; !d.isAfter(leaveEndDate); d = d.plusDays(1)) {
+				LocalTime dayHolStart = d.equals(holStartDate) ? holStartTime : LocalTime.MIN;
+				LocalTime dayHolEnd = d.equals(holEndDate) ? holEndTime : LocalTime.MAX;
+
+				LocalTime dayLeaveStart = d.equals(leaveStartDate) ? leaveStartTime : LocalTime.MIN;
+				LocalTime dayLeaveEnd = d.equals(leaveEndDate) ? leaveEndTime : LocalTime.MAX;
+
+				boolean covered = !dayLeaveStart.isBefore(dayHolStart)
+								  && !dayLeaveEnd.isAfter(dayHolEnd);
+				if (!covered) {
+					fullyCovered = false;
+					break;
+				}
+			}
+
+			if (fullyCovered) {
+				// 완전 포함된 연차는 삭제
+				leaveAndHolidayRepository.delete(leave);
+				rollbackCalendar(leave.getGoogleEventId());
+			} else {
+				// 부분 보정: 사용일수와 사유 재계산
+				Map<String, Object> info = calcUsedDaysAndGetComment(
+					leave.getStartDate(), leave.getStarTime(),
+					leave.getEndDate(),   leave.getEndTime()
+				);
+				double usedDays = (double) info.get("usedDays");
+				String reason  = ((String) info.get("comment"));
+
+				leave.updateUsedLeaveHours(usedDays);
+				leave.updateComment(reason);
+				leaveAndHolidayRepository.saveAndFlush(leave);
+			}
+		}
+	}
+
+	private void rollbackCalendar(String eventId) {
+		try { calendarClient.events().delete(GOOGLE_PERSONAL_CALENDAR_ID, eventId).execute(); }
+		catch (Exception ex) { log.error("캘린더 롤백 실패: {}", eventId, ex); }
+	}
+
+	private void validateLeave(CreateLeaveRequestDto dto) {
+		LocalDate start = dto.startDate();
+		DayOfWeek dow = start.getDayOfWeek();
+		if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY)
+			throw new IllegalArgumentException("연차는 주말을 시작일로 사용할 수 없습니다.");
+		if (isHoliday(start))
+			throw new IllegalArgumentException("연차 시작일이 휴일일 수 없습니다.");
+	}
+
+
+	private void saveEntity(CreateLeaveRequestDto dto, Member member, String eventId,
+		boolean isHoliday, double usedDays, String comment) {
+		LeaveAndHoliday ent = LeaveAndHoliday.of(dto, member, eventId);
+		ent.updateIsHoliday(isHoliday);
+		if (dto.leaveType().isConsumesLeave()) {
+			ent.updateUsedLeaveHours(usedDays);
+			ent.updateComment(comment);
+		}
+		leaveAndHolidayRepository.saveAndFlush(ent);
+	}
+
+
+	private Event createCalendarEvent(CreateLeaveRequestDto dto) {
+		Event event = new Event().setSummary(dto.title());
+		LocalDateTime s = LocalDateTime.of(dto.startDate(), dto.startTime());
+		LocalDateTime e = LocalDateTime.of(dto.endDate(), dto.endTime());
+		event.setDescription(dto.description());
+		if (dto.isAllDay()) {
+			event.setStart(new EventDateTime().setDate(new DateTime(dto.startDate().toString())));
+			event.setEnd(new EventDateTime().setDate(new DateTime(dto.endDate().plusDays(1).toString())));
+		} else {
+			event.setStart(new EventDateTime().setDateTime(
+				new DateTime(Date.from(s.atZone(ZoneId.of(DEFAULT_TIME_ZONE)).toInstant()))));
+			event.setEnd(new EventDateTime().setDateTime(
+				new DateTime(Date.from(e.atZone(ZoneId.of(DEFAULT_TIME_ZONE)).toInstant()))));
+		}
+		return event;
+	}
+
+	/**
+	 * 실제 연차 사용 “일수” 계산 + 연차 비차감 사유 추출
+	 */
+	private Map<String, Object> calcUsedDaysAndGetComment(LocalDate startDate, LocalTime startTime, LocalDate endDate,
+		LocalTime endTime) {
+
+		LocalDateTime start = LocalDateTime.of(startDate, startTime);
+		LocalDateTime end = LocalDateTime.of(endDate, endTime);
+
+		double totalMinutes = 0;
+		StringBuilder reasonBuilder = new StringBuilder();
+
+		// 날짜별 루프 (하루 단위 탐색)
+		for (LocalDate d = start.toLocalDate(); !d.isAfter(end.toLocalDate()); d = d.plusDays(1)) {
+
+			// 1) 주말 스킵
+			DayOfWeek dow = d.getDayOfWeek();
+			if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) {
+				reasonBuilder.append("[").append(d).append("] 주말 제외\n");
+				continue;
+			}
+
+			// 2) 전일 휴일 스킵
+			if (isHoliday(d)) {
+				reasonBuilder.append("[").append(d).append("] 전일 휴일 제외\n");
+				continue;
+			}
+
+			// 3) 부분 휴일 조회
+			List<LeaveAndHoliday> partials = leaveAndHolidayRepository
+				.findByStartDateAndIsHolidayTrueAndIsAllDayFalse(d);
+
+			// 4) 해당 날짜의 시작/종료 시각 결정
+			// 시작, 종료일이 아니라면 중간에 낀거니까 이건 1일 연차임이 자명 -> 일 시작, 종료 시간으로 세팅
+			LocalDateTime dayStart = d.equals(start.toLocalDate())
+				? start // 이번 반복이 시작일과 같다면 이 날짜의 연차 시작으로 봄
+				: d.atTime(WORK_START_TIME); // 이번 반복이 시작일이 아니라면 이 날짜의 08시로 시작
+
+			LocalDateTime dayEnd = d.equals(end.toLocalDate())
+				? end // 이번 반복의 종료일이 매개변수 종료일과 같다면 이 날짜의 연차 끝날로봄
+				: d.atTime(WORK_END_TIME); // 이번 반복이 연차 종료일이 아니라면(중간일 - 당연히 1일 연차니깐 일과 끝나는 시간으로 변경)
+
+			// 5) 점심만 일정 스킵
+			if (isOnlyLunch(dayStart, dayEnd)) {
+				reasonBuilder
+					.append("[").append(d).append("] 점심시간(12:00~13:00) 전부 제외\n");
+				continue;
+			}
+
+			// 6) 기본 분 계산
+			long minutes = Duration.between(dayStart, dayEnd).toMinutes();
+
+			// 7) 부분 휴일과 겹치는 분 차감
+			for (LeaveAndHoliday h : partials) {
+				LocalDateTime holStart = LocalDateTime.of(d, h.getStarTime());
+				LocalDateTime holEnd = LocalDateTime.of(d, h.getEndTime());
+
+				// 계산을 위해 요청 구간과 휴일 구간 겹치는 부분
+				LocalDateTime overlapStart = dayStart.isAfter(holStart) ? dayStart : holStart;
+				LocalDateTime overlapEnd = dayEnd.isBefore(holEnd) ? dayEnd : holEnd;
+
+				if (overlapEnd.isAfter(overlapStart)) {
+					long overlapMin = Duration.between(overlapStart, overlapEnd).toMinutes();
+					minutes -= overlapMin;
+					// 상세 사유: 시간 범위 표시
+					reasonBuilder
+						.append("[").append(d).append("] 부분 휴일 ")
+						.append(holStart.toLocalTime()).append("~")
+						.append(holEnd.toLocalTime())
+						.append(" 중 ").append(overlapMin).append("분 제외\n");
+				}
+			}
+
+			// 8) 점심시간이 겹치면 60분 차감
+			if (isLunchIncluded(dayStart.toLocalTime(), dayEnd.toLocalTime())) {
+				minutes -= 60;
+				reasonBuilder
+					.append("[").append(d).append("] 점심시간(12:00~13:00) 60분 제외\n");
+			}
+
+			// 00시 ~ 23:59:59 까지의 일정이면 1일 연차니까 8시간으로 변환
+			// 당일 연차일 경우 중 00시 ~ 23:59:59로 등록된거 있을 수 있기에 처리
+			// TODO : Dto에서 시간 조정하여 지우도록
+			if (minutes >= 480) {
+				minutes = 480;
+			}
+
+			totalMinutes += Math.max(0, minutes);
+		}
+
+		// 8시간 = 480분 → 1일
+		double usedDays = (totalMinutes / 60.0) / 8.0;
+		String reason = !reasonBuilder.isEmpty() ? reasonBuilder.toString() : "";
+
+		return Map.of(
+			"usedDays", usedDays,
+			"comment", reason
+		);
+	}
+
+	/**
+	 * 12:00~13:00 구간이 포함되는지
+	 */
+	private boolean isLunchIncluded(LocalTime st, LocalTime en) {
+		return !st.isAfter(LUNCH_START)   //  st ≤ 12:00
+			   && !en.isBefore(LUNCH_END);   //  en ≥ 13:00
+	}
+
+	/**
+	 * 12:00 ~ 13:00 구간 전부만 포함한 일정인지 여부
+	 */
+	private boolean isOnlyLunch(LocalDateTime start, LocalDateTime end) {
+		return !start.toLocalTime().isBefore(LUNCH_START)   // start ≥ 12:00
+			   && !end.toLocalTime().isAfter(LUNCH_END);       // end   ≤ 13:00
+	}
+
+	private boolean isHoliday(LocalDate startDate) {
+		// 하루종일 쉬는 날인지 반환 (기념일 & 휴일) -> 시작일만 안맞으면 사실 괜찮으니
+		return leaveAndHolidayRepository.existsByStartDateAndIsHolidayTrueAndIsAllDayTrue(startDate);
 	}
 
 	/**
@@ -209,7 +468,8 @@ public class CalendarService {
 	 * 공휴일 검증
 	 */
 	private void checkHolidayUpdateAllowed(LeaveAndHoliday leaveAndHoliday) {
-		if (leaveAndHoliday.getLeaveType() == LeaveType.PUBLIC_HOLIDAY || leaveAndHoliday.getLeaveType() == LeaveType.OTHER_PEOPLE) {
+		if (leaveAndHoliday.getLeaveType() == LeaveType.PUBLIC_HOLIDAY
+			|| leaveAndHoliday.getLeaveType() == LeaveType.OTHER_PEOPLE) {
 			throw new IllegalArgumentException("공휴일 이벤트와 비회원 이벤트는 조작할 수 없습니다.");
 		}
 	}
@@ -358,7 +618,7 @@ public class CalendarService {
 
 	private boolean checkOwnerOrAdminMember(Member member, LeaveAndHoliday leaveAndHoliday) {
 		// 로그인 안했으면 그냥 나가리
-		if(member == null) {
+		if (member == null) {
 			return false;
 		}
 		boolean isAdmin = member.isAdmin();

--- a/src/main/java/com/leavebridge/member/controller/MemberViewController.java
+++ b/src/main/java/com/leavebridge/member/controller/MemberViewController.java
@@ -3,7 +3,6 @@ package com.leavebridge.member.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import com.leavebridge.member.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class MemberViewController {
-
-	private final MemberService memberService;
 
 	@GetMapping("/member/login")
 	public String login() {

--- a/src/main/java/com/leavebridge/member/service/MemberService.java
+++ b/src/main/java/com/leavebridge/member/service/MemberService.java
@@ -1,20 +1,13 @@
 package com.leavebridge.member.service;
 
-import java.time.DayOfWeek;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
 
-import org.apache.coyote.BadRequestException;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
-import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
 import com.leavebridge.member.dto.LeaveDetailDto;
 import com.leavebridge.member.dto.MemberUsedLeavesResponseDto;
 import com.leavebridge.member.dto.RequestChangePasswordRequest;
@@ -31,17 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
-	private final LeaveAndHolidayRepository leaveRepository;
 	private final PasswordEncoder passwordEncoder;
-
-	private static final LocalTime WORK_START = LocalTime.of(8, 0, 0);
-	private static final LocalTime WORK_END = LocalTime.of(17, 0, 0);
-
-	/**
-	 * 점심시간(12~13) 분 단위 제외용 상수
-	 */
-	private static final LocalTime LUNCH_START = LocalTime.NOON;        // 12:00
-	private static final LocalTime LUNCH_END = LocalTime.of(13, 0);   // 13:00
 
 	/**
 	 * 연차 총 일수 - 만일 나중에 실제 서비스 이용 시 규정 상 지급되는 일수를 개인별로 다르게
@@ -73,7 +56,8 @@ public class MemberService {
 
 		// ③ 일정별 사용 시간(분) → 총 사용 일수 계산
 		double usedDays = leaves.stream()
-			.mapToDouble(this::calcUsedDays)
+			.mapToDouble(LeaveAndHoliday::getUsedLeaveHours)
+			.filter(Objects::nonNull)
 			.sum();
 
 		// 남은 일수 계산
@@ -81,86 +65,10 @@ public class MemberService {
 
 		// 상세 DTO 리스트
 		List<LeaveDetailDto> detailDtos = leaves.stream()
-			.map(leaveAndHoliday -> LeaveDetailDto.of(leaveAndHoliday, calcUsedDays(leaveAndHoliday)))
+			.map(leaveAndHoliday -> LeaveDetailDto.of(leaveAndHoliday, usedDays))
 			.toList();
 
 		return MemberUsedLeavesResponseDto.of(member, TOTAL_ANNUAL_DAYS, usedDays, remaining, detailDtos);
-	}
-
-	/**
-	 * LeaveAndHoliday → 사용 “일수” 환산 (하루 단위 분할)
-	 */
-	private double calcUsedDays(LeaveAndHoliday leaveAndHoliday) {
-
-		// 연차 소진 안될 일정이면 사용 시간 0 -> 공휴일, 회의, 공가 등
-		if (!leaveAndHoliday.getLeaveType().isDeductible()) {
-			return 0.0;
-		}
-
-		LocalDateTime start = LocalDateTime.of(leaveAndHoliday.getStartDate(), leaveAndHoliday.getStarTime());
-		LocalDateTime end = LocalDateTime.of(leaveAndHoliday.getEndDate(), leaveAndHoliday.getEndTime());
-
-		double totalMinutes = 0;
-
-		// 날짜별 루프 (하루 단위 탐색)
-		for (LocalDate d = start.toLocalDate(); !d.isAfter(end.toLocalDate()); d = d.plusDays(1)) {
-
-			// ──➤ ① 주말(토·일) 스킵 ─────────────────
-			DayOfWeek dow = d.getDayOfWeek();
-			if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) {
-				continue;               // 분/일 계산 없이 다음 날로
-			}
-
-			// 해당 날짜의 시작/종료 시각 결정
-			// 시작, 종료일이 아니라면 중간에 낀거니까 이건 1일 연차임이 자명 -> 일 시작, 종료 시간으로 세팅
-			LocalDateTime dayStart = d.equals(start.toLocalDate())
-				? start // 이번 반복이 시작일과 같다면 이 날짜의 연차 시작으로 봄
-				: d.atTime(WORK_START); // 이번 반복이 시작일이 아니라면 이 날짜의 08시로 시작
-
-			LocalDateTime dayEnd = d.equals(end.toLocalDate())
-				? end // 이번 반복의 종료일이 매개변수 종료일과 같다면 이 날짜의 연차 끝날로봄
-				: d.atTime(WORK_END); // 이번 반복이 연차 종료일이 아니라면(중간일 - 당연히 1일 연차니깐 일과 끝나는 시간으로 변경)
-
-			// ③ **“점심만 일정”이면 continue;**  ← 위치 이동
-			if (isOnlyLunch(dayStart, dayEnd)) {
-				continue;             // 차감 0, 다음 날로
-			}
-
-			// 하루 분 단위 근무시간
-			long minutes = Duration.between(dayStart, dayEnd).toMinutes();
-
-			// 점심시간이 겹치면 60분 차감
-			if (isLunchIncluded(dayStart.toLocalTime(), dayEnd.toLocalTime())) {
-				minutes -= 60;
-			}
-
-			// 00시 ~ 23:59:59 까지의 일정이면 1일 연차니까 8시간으로 변환
-			// 당일 연차일 경우 중 00시 ~ 23:59:59로 등록된거 있을 수 있기에 처리
-			if (minutes >= 480) {
-				minutes = 480;
-			}
-
-			totalMinutes += minutes;
-		}
-
-		// 8시간 = 480분 → 1일
-		return (totalMinutes / 60.0) / 8.0;
-	}
-
-	/**
-	 * 12:00~13:00 구간이 포함되는지
-	 */
-	private boolean isLunchIncluded(LocalTime st, LocalTime en) {
-		return !st.isAfter(LUNCH_START)   //  st ≤ 12:00
-			   && !en.isBefore(LUNCH_END);   //  en ≥ 13:00
-	}
-
-	/**
-	 * 12:00 ~ 13:00 구간 전부만 포함한 일정인지 여부
-	 */
-	private boolean isOnlyLunch(LocalDateTime start, LocalDateTime end) {
-		return !start.toLocalTime().isBefore(LUNCH_START)   // start ≥ 12:00
-			   && !end.toLocalTime().isAfter(LUNCH_END);       // end   ≤ 13:00
 	}
 
 	@Transactional

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -13,6 +13,21 @@
             background-color: #f0f8ff;
             cursor: pointer;
         }
+
+        /* dayGrid(월간) 뷰의 all‑day 이벤트 */
+        .fc .fc-daygrid-event {
+            margin-bottom: 4px;    /* 아래쪽 간격 */
+        }
+
+        /* timeGrid(시간) 뷰의 이벤트 컨테이너 */
+        .fc .fc-timegrid-event-harness {
+            margin-bottom: 4px;    /* 아래쪽 간격 */
+        }
+
+        /* 필요하면 좌우 간격도 추가 */
+        .fc .fc-event {
+            margin: 2px 0;         /* 세로 2px 여백 */
+        }
     </style>
 </head>
 <div layout:fragment="content">
@@ -70,7 +85,7 @@
                             한 번에 하나의 연차 타입만 등록 가능합니다. 다른 타입은 별도 등록해 주세요.
                         </div>
                         <div class="form-text fw-bold" sec:authorize="hasRole('ADMIN')" id="holidayNotice" style="display: none;">
-                            휴일 포함 체크시 해당 기간동안 연차 등록이 불가능합니다.
+                            휴일 포함 체크시 기존에 등록된 연차들은 차감 연차 조정되거나 삭제됩니다.
                         </div>
                     </div>
 
@@ -487,7 +502,9 @@
                 aspectRatio: 1.5, // 너비: 높이 비율 1.5:1 (종횡비)
                 eventColor: '#3799d8',  // 기본 일정 배경색 설정 (파란색)
                 eventTextColor: '#ffffff',  // 글자 색상 변경
-                dayMaxEvents: true,  // 하루 최대 이벤트 표시(true 인경우 적절히)
+                dayMaxEvents: false,  // 하루 최대 이벤트 표시(true 인경우 적절히)
+                eventOrder: 'duration, start',  // duration이 긴(다중일) 이벤트 우선 렌더
+                eventDisplay: 'block',        // 이벤트가 블록으로 렌더
                 // moreLinkClick: function (info) {
                 //     alert('더보기 클릭: ' + info.data);
                 //     // 여기서 팝업을 열거나 다른 행동 정의할 수 있음


### PR DESCRIPTION
## 구현 사항 요약
- 프론트 일부 수정
  - Full Calendar 일정 끝나는날 +1하여 달력 표기 정상적이도록 수정(Full Calendar API 특성)
  - CSS 조정하여 일정 간 gap 있게
- 일정 사용 현황 API 수정
- 일정 등록 시 사용 연차 계산 하도록 변경
- 휴일 등록 시 등록하려는 휴일 일정에 포함된 기존 연차 있으면 삭제 or 연차 사용 시간 조정

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장 + **해당 일정이 얼마만큼의 연차를 소진한건지 double 컬럼 추가**
  - [x] `MEMBER` : 사용자 정보 저장
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [ ] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신
    - [ ] (추가) 일정 수정 시 등록과 마찬가지로 수정된 휴일 내 포함된 연차 일정 모두 삭제 or 연차 시간 수정
    - [ ] (추가) 일정 수정 시 수정하려는 일정이 휴일 등으로 연차 사용 시간이 0시간이라면 수정 튕겨내도록 수정

  - [x] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신

- [x] 로그인 페이지

- [ ] 연차 사용 현황 페이지

- [x] 비밀번호 변경 페이지
- [x] 비밀번호 변경 API

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [ ] API 리팩토링
  - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [ ] Query DSL 도입하여 Dto로 응답 바로 받을 수 있는것들 처리 등
  - [x] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [x] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현