### PR TITLE
Cheorhyeon

### DIFF
--- a/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
+++ b/src/main/java/com/leavebridge/calendar/dto/MonthlyEventDetailResponse.java
@@ -1,6 +1,7 @@
 package com.leavebridge.calendar.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
 import com.leavebridge.calendar.enums.LeaveType;
@@ -14,10 +15,14 @@ public record MonthlyEventDetailResponse(
 	Long id,
 	@Schema(description = "일정 제목", example = "박철현 연차")
 	String title,
-	@Schema(description = "시작 시간", example = "2025-07-01T14:00:00")
-	LocalDateTime startDate,
-	@Schema(description = "종료 시간", example = "2025-07-01T14:00:00")
-	LocalDateTime endDate,
+	@Schema(description = "시작 일자", example = "2025-07-01")
+	LocalDate startDate,
+	@Schema(description = "시작 시간", example = "08:00:00")
+	LocalTime startTime,
+	@Schema(description = "종료 일자", example = "2025-07-01")
+	LocalDate endDate,
+	@Schema(description = "종료 시간", example = "14:00:00")
+	LocalTime endTime,
 	@Schema(description = "하루 종일 이벤트 여부", example = "true or false")
 	Boolean isAllDay,
 	@Schema(description = "연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_LEAVE(반차),  OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차)")
@@ -33,8 +38,10 @@ public record MonthlyEventDetailResponse(
 		return MonthlyEventDetailResponse.builder()
 			.id(leaveAndHoliday.getId())
 			.title(leaveAndHoliday.getTitle())
-			.startDate(LocalDateTime.of(leaveAndHoliday.getStartDate(), leaveAndHoliday.getStarTime()))
-			.endDate(LocalDateTime.of(leaveAndHoliday.getEndDate(), leaveAndHoliday.getEndTime()))
+			.startDate(leaveAndHoliday.getStartDate())
+			.startTime(leaveAndHoliday.getStarTime())
+			.endDate(leaveAndHoliday.getEndDate())
+			.endTime(leaveAndHoliday.getEndTime())
 			.isAllDay(leaveAndHoliday.getIsAllDay())
 			.leaveType(leaveAndHoliday.getLeaveType())
 			.description(leaveAndHoliday.getDescription())

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -16,17 +16,23 @@
 
         /* dayGrid(월간) 뷰의 all‑day 이벤트 */
         .fc .fc-daygrid-event {
-            margin-bottom: 4px;    /* 아래쪽 간격 */
+            margin-bottom: 4px; /* 아래쪽 간격 */
         }
 
         /* timeGrid(시간) 뷰의 이벤트 컨테이너 */
         .fc .fc-timegrid-event-harness {
-            margin-bottom: 4px;    /* 아래쪽 간격 */
+            margin-bottom: 4px; /* 아래쪽 간격 */
         }
 
         /* 필요하면 좌우 간격도 추가 */
         .fc .fc-event {
-            margin: 2px 0;         /* 세로 2px 여백 */
+            margin: 2px 0; /* 세로 2px 여백 */
+        }
+
+        .select-readonly {
+            pointer-events: none;      /* 클릭 불가 */
+            background-color: #e9ecef; /* 입력 불가 느낌 */
+            opacity: 1;                /* 흐려짐 방지 */
         }
     </style>
 </head>
@@ -84,7 +90,8 @@
                         <div class="form-text fw-bold">
                             한 번에 하나의 연차 타입만 등록 가능합니다. 다른 타입은 별도 등록해 주세요.
                         </div>
-                        <div class="form-text fw-bold" sec:authorize="hasRole('ADMIN')" id="holidayNotice" style="display: none;">
+                        <div class="form-text fw-bold" sec:authorize="hasRole('ADMIN')" id="holidayNotice"
+                             style="display: none;">
                             휴일 포함 체크시 기존에 등록된 연차들은 차감 연차 조정되거나 삭제됩니다.
                         </div>
                     </div>
@@ -237,18 +244,26 @@
         /*
             좀 더 친숙한 시간 표현대로 변경하는 함수
          */
-        function formatKoreanDateTime(isoString) {
-            const date = new Date(isoString);
-            const formatter = new Intl.DateTimeFormat('ko-KR', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-                hour: 'numeric',
+        function formatKoreanDateTime(dateStr, timeStr) {
+            // ISO 문자열로 합치기
+            // timeStr이 초(sec)까지 포함하지 않을 수도 있어서 pad 보장
+            const normalizedTime = timeStr.length === 5
+                ? `${timeStr}:00`
+                : timeStr;
+            const isoString = `${dateStr}T${normalizedTime}`;
+
+            // Date 객체 생성 (로컬 타임존 기반)
+            const dt = new Date(isoString);
+
+            // Intl.DateTimeFormat 으로 한 번에 포맷
+            return new Intl.DateTimeFormat('ko-KR', {
+                year:   'numeric',
+                month:  'long',
+                day:    'numeric',
+                hour:   'numeric',
                 minute: 'numeric',
                 hour12: true
-            });
-            // 예: "2025년 7월 10일 오후 2:00"
-            return formatter.format(date);
+            }).format(dt);
         }
 
         function onModifyToggleAllDayChange() {
@@ -263,8 +278,8 @@
                 endTime.required = false;
 
                 // 범위·값 모두 제거
-                startTime.value = '';
-                endTime.value = '';
+                startTime.value = '00:00';
+                endTime.value   = '23:59';
                 startTime.removeAttribute('min');
                 startTime.removeAttribute('max');
                 endTime.removeAttribute('min');
@@ -274,6 +289,9 @@
                 timeGroup.style.display = '';
                 startTime.required = true;
                 endTime.required = true;
+
+                startTime.value = '';
+                endTime.value   = '';
             }
         }
 
@@ -300,7 +318,7 @@
             const modalDeleteBtn = document.getElementById('modalDeleteBtn');
             const deleteConfirmModal = new bootstrap.Modal(document.getElementById('deleteConfirmModal'));
             const confirmDeleteBtn = document.getElementById('confirmDeleteBtn');
-            const allDayCheck         = document.getElementById('allDayCheck');
+            const allDayCheck = document.getElementById('allDayCheck');
             const holidayIncludeCheck = document.getElementById('holidayIncludeCheck');
             const holidayIncludeGroup = holidayIncludeCheck?.closest('.form-check');
             const holidayNotice = document.getElementById('holidayNotice');
@@ -308,7 +326,9 @@
             if (holidayIncludeGroup) {
                 holidayIncludeGroup.style.display = 'none';
             }
+
             let currentEventId = null;  // 수정 중인 이벤트 ID 보관
+            let currentIsHoliday = false; // ← 전역 변수로 휴일 여부 저장
 
             allDayCheck.addEventListener('change', onModifyToggleAllDayChange);
 
@@ -331,22 +351,24 @@
 
             let anchorDate = null;         // 폼이 열릴 때 클릭한 날짜 기억
 
-            // 3) leaveType 변경 시 UI 조정
-            function onLeaveTypeChange() {
-                const isHoliday = ['PUBLIC_HOLIDAY','ANNIVERSARY'].includes(leaveTypeEl.value);
-                const currentType = leaveTypeEl.value;
-
-                // holidayIncludeCheck 요소가 실제로 존재할 때만 동작
+            function toggleHolidayIncludeUI(isHoliday) {
                 if (typeof holidayIncludeCheck !== 'undefined' && holidayIncludeCheck !== null) {
                     // 1) 공휴일/기념일일 때만 보이기
                     holidayIncludeGroup.style.display = isHoliday ? '' : 'none';
                     holidayNotice.style.display = isHoliday ? '' : 'none';
 
-                    // 2) 공휴일이 아니면 체크 해제
-                    if (!isHoliday) {
-                        holidayIncludeCheck.checked = false;
-                    }
+                    // 2) 해당 일정이 휴일 여부에 따라 체크(최초 등록때는 안됨, 상세 조회 시에는 체크 여부 변경되게)
+                    holidayIncludeCheck.checked = currentIsHoliday;
                 }
+            }
+
+            // 3) leaveType 변경 시 UI 조정
+            function onLeaveTypeChange() {
+                const isHoliday = ['PUBLIC_HOLIDAY', 'ANNIVERSARY'].includes(leaveTypeEl.value);
+                const currentType = leaveTypeEl.value;
+
+                // holidayIncludeCheck 요소가 실제로 존재할 때만 동작
+                toggleHolidayIncludeUI(isHoliday)
                 // 0) 기본 리셋 (페어된 로직만 남김)
                 allDayCheck.disabled = false;
                 startTimeEl.required = false;
@@ -465,22 +487,57 @@
                 fetch(`/api/v1/calendar/events/${eventId}`)
                     .then(res => res.json())
                     .then(evt => {
+                        // 전역 변수에 isHoliday 저장
+                        currentIsHoliday = evt.isHoliday;
+
                         // 2) 폼 필드에 값 채우기
                         titleInput.value = evt.title;
                         leaveTypeEl.value = evt.leaveType;
-                        startDateEl.value = evt.startDate.slice(0, 10);
-                        endDateEl.value = evt.endDate.slice(0, 10);
+                        startDateEl.value = evt.startDate;
+                        endDateEl.value = evt.endDate;
+                        startTimeEl.value = evt.startTime;
+                        endTimeEl.value   = evt.endTime;
+
                         if (!evt.isAllDay) {
                             allDayCheck.checked = false;
-                            startTimeEl.value = evt.startDate.slice(11, 16);
-                            endTimeEl.value = evt.endDate.slice(11, 16);
+                            startTimeEl.value = evt.startDate;
+                            endTimeEl.value = evt.endDate;
                         } else {
                             allDayCheck.checked = true;
                         }
+                        // holidayIncludeCheck 엘리먼트가 있을 때만 접근
+                        if (holidayIncludeCheck) {
+                            holidayIncludeCheck.checked = Boolean(evt.isHoliday);
+                            // 수정 불가 설정도 함께
+                            holidayIncludeCheck.disabled = currentIsHoliday;
+                        }
                         descriptionEl.value = evt.description || '';
 
-                        // 3) onLeaveTypeChange 등 UI 토글 함수 호출
-                        onLeaveTypeChange();
+                        // isHoliday인 경우 → 수정 불가 필드 비활성화
+                        if (currentIsHoliday) {
+                            // 날짜, 시간, all-day, 휴일 포함 체크박스 전부 비활성화
+                            startDateEl.readOnly = true;
+                            endDateEl.readOnly = true;
+                            allDayCheck.disabled = true;
+                            if (holidayIncludeCheck) holidayIncludeCheck.disabled = true;
+                            startTimeEl.readOnly = true;
+                            endTimeEl.readOnly = true;
+                            leaveTypeEl.disabled = true;
+                            toggleHolidayIncludeUI(currentIsHoliday)
+                            holidayNotice.textContent = '등록된 휴일의 일정을 조절할 수 없습니다. 조절이 필요하면 삭제 후 다시 일정을 생성하세요.';
+                            holidayNotice.style.display = '';  // 보이도록
+                        } else {
+                            // 일반 일정이면 leaveType까지 편집 가능
+                            startDateEl.readOnly = false;
+                            endDateEl.readOnly = false;
+                            allDayCheck.disabled = false;
+                            if (holidayIncludeCheck) holidayIncludeCheck.disabled = false;
+                            startTimeEl.readOnly = false;
+                            endTimeEl.readOnly = false;
+                            leaveTypeEl.disabled = false;
+                            // 3) onLeaveTypeChange 등 UI 토글 함수 호출
+                            onLeaveTypeChange();
+                        }
 
                         formModal.show();
                     })
@@ -549,15 +606,15 @@
                         .then(events => {
                             // events 는 MonthlyEvent DTO 배열이라고 가정
                             return events.map(evt => ({
-                                id:             evt.id,
-                                title:          evt.title,
-                                start:          evt.start,
-                                end:            evt.end,
-                                allDay:         evt.allDay,
+                                id: evt.id,
+                                title: evt.title,
+                                start: evt.start,
+                                end: evt.end,
+                                allDay: evt.allDay,
                                 // isHoliday 플래그에 따라 색상 지정
                                 backgroundColor: evt.isHoliday ? '#dc3545' : undefined,
-                                borderColor:     evt.isHoliday ? '#dc3545' : undefined,
-                                textColor:       evt.isHoliday ? '#ffffff' : undefined,
+                                borderColor: evt.isHoliday ? '#dc3545' : undefined,
+                                textColor: evt.isHoliday ? '#ffffff' : undefined,
                             }));
                             successCallback(fcEvents);
                         })
@@ -566,7 +623,8 @@
                             showToast('일정을 불러오는 중 오류가 발생했습니다.', 'error');
                             // 실패 콜백에 빈 배열을 넘겨줘서 캘린더가 비어 있게 함
                             failureCallback([]);
-                        });;
+                        });
+                    ;
                 },
 
                 // event 클릭 함수 정의 -> 일정 정보 (수정, 삭제 가능하도록)
@@ -582,8 +640,8 @@
                         .then(data => {
                             // 모달 내부 요소에 데이터 채우기
                             document.getElementById('modalTitle').textContent = data.title;
-                            document.getElementById('modalStart').textContent = formatKoreanDateTime(data.startDate);
-                            document.getElementById('modalEnd').textContent = formatKoreanDateTime(data.endDate);
+                            document.getElementById('modalStart').textContent = formatKoreanDateTime(data.startDate, data.startTime);
+                            document.getElementById('modalEnd').textContent = formatKoreanDateTime(data.endDate, data.endTime);
                             document.getElementById('modalDescription').textContent = data.description || '설명 없음';
 
                             // 수정 버튼에 eventId 속성으로 넣기
@@ -602,7 +660,7 @@
                             // 휴일 라벨·정보 토글
                             const isHoliday = data.isHoliday;
                             document.getElementById('modalHolidayLabel').style.display = isHoliday ? '' : 'none';
-                            document.getElementById('modalHolidayInfo' ).style.display = isHoliday ? '' : 'none';
+                            document.getElementById('modalHolidayInfo').style.display = isHoliday ? '' : 'none';
 
                             if (isHoliday) {
                                 let text;
@@ -725,8 +783,16 @@
                     : '/api/v1/calendar/events';
                 const method = currentEventId ? 'PATCH' : 'POST';
 
+                // ① disabled 풀고
+                const disabledEls = eventForm.querySelectorAll('[disabled]');
+                disabledEls.forEach(el => el.disabled = false);
+
+                // ② FormData 뽑기
                 const formData = new FormData(eventForm);
                 const dataObj = Object.fromEntries(formData.entries());
+
+                // ③ 다시 disabled 복귀
+                disabledEls.forEach(el => el.disabled = true);
 
                 // 2) allDay 키가 없으면 기본 false 주입 (문자열 → boolean 변환 포함)
                 dataObj.isAllDay = document.getElementById('allDayCheck').checked; // true / false


### PR DESCRIPTION
## 구현 사항 요약
- 일정 상세 조회 시 날짜와 시간 분리하여 내려주도록 수정 (다른 API와 통일)
- 일정 수정 제약 조건 추가
  - 관리자만 휴일, 공휴일, 기념일 등 수정가능하도록
  - 연차 소진 일정의 경우 주말, 휴일날 시작할 수 없도록

  - 휴일 여부 변경 불가 & 휴일 일정 변경 금지
    - 사유 : 휴일 등록할 때 기간이 겹친 연차를 삭제하거나 연차 사용횟수를 조정했는데 삭제한걸 복구하기엔 매우 어렵기에 변경 불가하도록
    - 변경이 필요하면 삭제하고 다시 일정 만들도록 안내

- 연차 소진 <-> 미소진 변경 불가
  - 타입이 달라지는건 삭제하고 다시 만드는것이 간편


## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장 + **해당 일정이 얼마만큼의 연차를 소진한건지 double 컬럼 추가**
  - [x] `MEMBER` : 사용자 정보 저장
- [x] Spring Security 도입
  - [x] form_login 도입

- [ ] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신
    - [x] (추가) 휴일 일정 변경, 휴일 여부 변경 등 삭제하고 다시 생성하도록 입구컷
    - [x] (추가) 일정 수정 시 수정하려는 일정이 휴일 등으로 연차 사용 시간이 0시간이라면 수정 튕겨내도록 수정
      - 사실 이미 삭제되었을 것

  - [ ] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신
    - [ ] (추가) 휴일 삭제할 경우 해당 기간에 속한 연차들 다시 불러와서 연차 기간 다시 계산하도록

- [x] 로그인 페이지

- [ ] 연차 사용 현황 페이지

- [x] 비밀번호 변경 페이지
- [x] 비밀번호 변경 API

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [ ] API 리팩토링
  - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [x] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [x] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현