### PR TITLE
Cheorhyeon

### DIFF
--- a/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
+++ b/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
@@ -19,8 +19,6 @@ public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday
 
 	boolean existsByStartDateAndIsHolidayTrueAndIsAllDayTrue(LocalDate start);
 
-	List<LeaveAndHoliday> findByStartDateAndIsHolidayTrueAndIsAllDayFalse(LocalDate startDate);
-
 	@Query("""
 		   SELECT l FROM LeaveAndHoliday l
 		WHERE (l.isHoliday = false OR l.isHoliday IS NULL)
@@ -33,4 +31,7 @@ public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday
 		@Param("holidayEnd")   LocalDate holidayEnd,
 		@Param("consumesLeaveTypes") List<LeaveType> consumesLeaveTypes
 	);
+
+	List<LeaveAndHoliday> findByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayFalse(
+		LocalDate endDate, LocalDate startDate);
 }

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -266,6 +266,117 @@ public class CalendarService {
 		return event;
 	}
 
+	// LeaveAndHoliday에서 LocalDateTime 구간 추출용 DTO
+	@Getter
+	static class DateTimeInterval {
+		private final LocalDateTime start;
+		private final LocalDateTime end;
+
+		public DateTimeInterval(LocalDateTime start, LocalDateTime end) {
+			this.start = start;
+			this.end = end;
+		}
+
+		public boolean isLunchTime() {
+			return start.toLocalTime().equals(LUNCH_START) && end.toLocalTime().equals(LUNCH_END);
+		}
+	}
+
+	/**
+	 * 주어진 부분 휴일들의 겹치는 시간을 합하여 최종적으로 제외할 시간들 리스트 반환 함수
+	 */
+	private List<DateTimeInterval> mergedHolidayTimesWithLunchTime(
+		List<LeaveAndHoliday> partials,
+		LocalDate targetDate
+	) {
+		List<DateTimeInterval> intervals = new ArrayList<>();
+
+		for (LeaveAndHoliday h : partials) {
+			// 1) 이 건이 targetDate를 포함하므로, 날짜 루프 불필요
+			// rawStart: 휴일이 targetDate 이전부터 시작됐다면 근무시작, 아니면 실제 시작시간
+			LocalTime rawStart = h.getStartDate().isBefore(targetDate)
+				? WORK_START_TIME
+				: h.getStarTime();
+			// rawEnd: 휴일이 targetDate 이후까지 이어진다면 근무종료, 아니면 실제 종료시간
+			LocalTime rawEnd = h.getEndDate().isAfter(targetDate)
+				? WORK_END_TIME
+				: h.getEndTime();
+
+			// 2) 근무시간 범위로 클램핑
+			LocalTime startT = rawStart.isBefore(WORK_START_TIME) ? WORK_START_TIME : rawStart;
+			LocalTime endT = rawEnd.isAfter(WORK_END_TIME) ? WORK_END_TIME : rawEnd;
+
+			// 3) 유효 구간이면 (시작 18시, 종료 19시면 안맞게되는 등)
+			if (startT.isBefore(endT)) {
+				boolean overlapsLunch =
+					startT.isBefore(LUNCH_END) && endT.isAfter(LUNCH_START);
+
+				if (overlapsLunch) {
+					// 점심 전 구간
+					if (startT.isBefore(LUNCH_START)) {
+						intervals.add(new DateTimeInterval(
+							LocalDateTime.of(targetDate, startT),
+							LocalDateTime.of(targetDate, LUNCH_START)
+						));
+					}
+					// 점심 후 구간
+					if (endT.isAfter(LUNCH_END)) {
+						intervals.add(new DateTimeInterval(
+							LocalDateTime.of(targetDate, LUNCH_END),
+							LocalDateTime.of(targetDate, endT)
+						));
+					}
+				} else {
+					// 점심과 겹치지 않으면 그대로 추가
+					intervals.add(new DateTimeInterval(
+						LocalDateTime.of(targetDate, startT),
+						LocalDateTime.of(targetDate, endT)
+					));
+				}
+			}
+		}
+
+		// 병합
+		return mergeIntervals(intervals);
+	}
+
+	/**
+	 * 주어진 (시작,종료) 구간들을 겹침 및 연속 포함해서 최대 병합한 리스트로 반환
+	 */
+	public static List<DateTimeInterval> mergeIntervals(List<DateTimeInterval> intervals) {
+		if (intervals.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		// 1) 시작 시간 기준으로 정렬 (LocalDateTime 비교)
+		intervals.sort(Comparator.comparing(DateTimeInterval::getStart));
+
+		List<DateTimeInterval> merged = new ArrayList<>();
+		// 2) 첫 구간으로 시작
+		DateTimeInterval current = intervals.get(0);
+
+		for (int i = 1; i < intervals.size(); i++) {
+			DateTimeInterval next = intervals.get(i);
+
+			// "겹치거나 연속" (current.end >= next.start)일 때 병합
+			if (!current.getEnd().isBefore(next.getStart())) {
+				// end 시각을 둘 중 더 늦은 쪽으로 연장
+				LocalDateTime newEnd = current.getEnd().isAfter(next.getEnd())
+					? current.getEnd()
+					: next.getEnd();
+				current = new DateTimeInterval(current.getStart(), newEnd);
+			} else {
+				// 틈이 있으면, 지금까지 병합된 current를 결과에 추가하고 next를 새로운 current로
+				merged.add(current);
+				current = next;
+			}
+		}
+		// 마지막 구간 추가
+		merged.add(current);
+
+		return merged;
+	}
+
 	/**
 	 * 실제 연차 사용 “일수” 계산 + 연차 비차감 사유 추출
 	 */
@@ -277,6 +388,35 @@ public class CalendarService {
 
 		double totalMinutes = 0;
 		StringBuilder reasonBuilder = new StringBuilder();
+
+		// 전체 구간(startDate~endDate)에 걸친 “부분 휴일”만 미리 가져온다.
+		List<LeaveAndHoliday> allPartials = leaveAndHolidayRepository
+			.findByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayFalse(
+				endDate, startDate
+			);
+
+		/**
+		 * 적용 날짜 : [휴일 엔티티] 묶어줌 (여러 일 거친것도 특정일 기준으로 검사할 수 있게)
+		 * h1: 7/13 ~ 7/15, h2: 7/14 ~ 7/14, h3: 7/16 ~ 7/17
+		 * partialsByDate.get(2025-07-13) → [h1]
+		 * partialsByDate.get(2025-07-14) → [h1, h2]
+		 * partialsByDate.get(2025-07-15) → [h1]
+		 * partialsByDate.get(2025-07-16) → [h3]
+		 * partialsByDate.get(2025-07-17) → [h3]
+		 */
+		Map<LocalDate, List<LeaveAndHoliday>> partialsByDate = new HashMap<>();
+		for (LeaveAndHoliday h : allPartials) {
+			LocalDate from = h.getStartDate();
+			LocalDate to = h.getEndDate();
+			for (LocalDate d = from; !d.isAfter(to); d = d.plusDays(1)) {
+				// map에 key d가 없으면 새 리스트 생성
+				if (!partialsByDate.containsKey(d)) {
+					partialsByDate.put(d, new ArrayList<>());
+				}
+				// 해당 날짜 리스트에 h 추가
+				partialsByDate.get(d).add(h);
+			}
+		}
 
 		// 날짜별 루프 (하루 단위 탐색)
 		for (LocalDate d = start.toLocalDate(); !d.isAfter(end.toLocalDate()); d = d.plusDays(1)) {
@@ -290,13 +430,12 @@ public class CalendarService {
 
 			// 2) 전일 휴일 스킵
 			if (isHoliday(d)) {
-				reasonBuilder.append("[").append(d).append("] 전일 휴일 제외\n");
+				reasonBuilder.append("[").append(d).append("] 전일 휴일이 포함된 일정 제외\n");
 				continue;
 			}
 
-			// 3) 부분 휴일 조회
-			List<LeaveAndHoliday> partials = leaveAndHolidayRepository
-				.findByStartDateAndIsHolidayTrueAndIsAllDayFalse(d);
+			// 3) 부분 휴일 조회 - 지금 연차 계산일이 포함된 일정 가져오기
+			List<LeaveAndHoliday> partials = partialsByDate.getOrDefault(d, Collections.emptyList());
 
 			// 4) 해당 날짜의 시작/종료 시각 결정
 			// 시작, 종료일이 아니라면 중간에 낀거니까 이건 1일 연차임이 자명 -> 일 시작, 종료 시간으로 세팅
@@ -308,42 +447,43 @@ public class CalendarService {
 				? end // 이번 반복의 종료일이 매개변수 종료일과 같다면 이 날짜의 연차 끝날로봄
 				: d.atTime(WORK_END_TIME); // 이번 반복이 연차 종료일이 아니라면(중간일 - 당연히 1일 연차니깐 일과 끝나는 시간으로 변경)
 
-			// 5) 점심만 일정 스킵
+			// 5) 점심시간에만 있는 일정 스킵
 			if (isOnlyLunch(dayStart, dayEnd)) {
 				reasonBuilder
 					.append("[").append(d).append("] 점심시간(12:00~13:00) 전부 제외\n");
 				continue;
 			}
 
-			// 6) 기본 분 계산
+			// 6) 해당 일자에 이미 존재하는 휴일들의 시간 중복을 합친 새로운 일정 반환(d 날짜의 점심시간도 항상 포함)
+			List<DateTimeInterval> intervals = mergedHolidayTimesWithLunchTime(partials, d);
+
+			// 7) 기본 분 계산 - 점심시간 포함하면 1시간 제외
 			long minutes = Duration.between(dayStart, dayEnd).toMinutes();
+			if (isLunchIncluded(dayStart.toLocalTime(), dayEnd.toLocalTime())) {
+				minutes -= 60;
+			}
+			long overlapMin = 0;
 
-			// 7) 부분 휴일과 겹치는 분 차감
-			for (LeaveAndHoliday h : partials) {
-				LocalDateTime holStart = LocalDateTime.of(d, h.getStarTime());
-				LocalDateTime holEnd = LocalDateTime.of(d, h.getEndTime());
+			// 8) 부분 휴일과 겹치는 분 차감
+			for (DateTimeInterval interval : intervals) {
+				LocalDateTime holStart = interval.getStart();
+				LocalDateTime holEnd = interval.getEnd();
 
-				// 계산을 위해 요청 구간과 휴일 구간 겹치는 부분
+				// 계산을 위해 요청 구간과 휴일 구간 겹치는 부분(시작점, 종료점) 추출
 				LocalDateTime overlapStart = dayStart.isAfter(holStart) ? dayStart : holStart;
 				LocalDateTime overlapEnd = dayEnd.isBefore(holEnd) ? dayEnd : holEnd;
 
+				// 부분 휴일과 겹치는 부분을 사용한 연차에서 제외
 				if (overlapEnd.isAfter(overlapStart)) {
-					long overlapMin = Duration.between(overlapStart, overlapEnd).toMinutes();
-					minutes -= overlapMin;
-					// 상세 사유: 시간 범위 표시
-					reasonBuilder
-						.append("[").append(d).append("] 부분 휴일 ")
-						.append(holStart.toLocalTime()).append("~")
-						.append(holEnd.toLocalTime())
-						.append(" 중 ").append(overlapMin).append("분 제외\n");
+					overlapMin += Duration.between(overlapStart, overlapEnd).toMinutes();
 				}
 			}
 
-			// 8) 점심시간이 겹치면 60분 차감
-			if (isLunchIncluded(dayStart.toLocalTime(), dayEnd.toLocalTime())) {
-				minutes -= 60;
+			minutes -= overlapMin;
+			if (overlapMin > 0) {
 				reasonBuilder
-					.append("[").append(d).append("] 점심시간(12:00~13:00) 60분 제외\n");
+					.append("[").append(d).append("] 부분 휴일 ")
+					.append(overlapMin).append("분 제외");
 			}
 
 			totalMinutes += Math.max(0, minutes);
@@ -448,7 +588,8 @@ public class CalendarService {
 			String comment = ((String)info.get("comment"));
 
 			if (usedDays == 0.0) {
-				throw new IllegalArgumentException("해당 기간에 휴일/주말만 포함되어 실제 연차 소진이 없게되어 수정할 수 없습니다.");
+				throw new IllegalArgumentException("해당 기간에는 휴일·주말만 포함되어 실제 차감 연차가 없습니다. " +
+												   "변경하시려면 기존 일정을 삭제한 후 다시 등록해주세요.");
 			}
 
 			leaveAndHoliday.updateUsedLeaveHours(usedDays);

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -30,9 +30,9 @@
         }
 
         .select-readonly {
-            pointer-events: none;      /* 클릭 불가 */
+            pointer-events: none; /* 클릭 불가 */
             background-color: #e9ecef; /* 입력 불가 느낌 */
-            opacity: 1;                /* 흐려짐 방지 */
+            opacity: 1; /* 흐려짐 방지 */
         }
     </style>
 </head>
@@ -114,7 +114,7 @@
                         <div class="col">
                             <label for="inputStartTime" class="form-label">시작 시간</label>
                             <input type="time" class="form-control" id="inputStartTime" name="startTime">
-                            <div class="invalid-feedback">시작 시간은 종료 시간보다 빠를 수 없습니다.</div>
+                            <div class="invalid-feedback">시작 시간은 종료 시간보다 늦을 수 없습니다.</div>
                         </div>
                         <div class="col">
                             <label for="inputEndTime" class="form-label">종료 시간</label>
@@ -257,10 +257,10 @@
 
             // Intl.DateTimeFormat 으로 한 번에 포맷
             return new Intl.DateTimeFormat('ko-KR', {
-                year:   'numeric',
-                month:  'long',
-                day:    'numeric',
-                hour:   'numeric',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: 'numeric',
                 minute: 'numeric',
                 hour12: true
             }).format(dt);
@@ -279,7 +279,7 @@
 
                 // 범위·값 모두 제거
                 startTime.value = '00:00';
-                endTime.value   = '23:59';
+                endTime.value = '23:59';
                 startTime.removeAttribute('min');
                 startTime.removeAttribute('max');
                 endTime.removeAttribute('min');
@@ -291,7 +291,7 @@
                 endTime.required = true;
 
                 startTime.value = '';
-                endTime.value   = '';
+                endTime.value = '';
             }
         }
 
@@ -496,7 +496,7 @@
                         startDateEl.value = evt.startDate;
                         endDateEl.value = evt.endDate;
                         startTimeEl.value = evt.startTime;
-                        endTimeEl.value   = evt.endTime;
+                        endTimeEl.value = evt.endTime;
 
                         if (!evt.isAllDay) {
                             allDayCheck.checked = false;
@@ -718,7 +718,34 @@
                     document.getElementById('inputStartDate').value = info.dateStr;
                     document.getElementById('inputEndDate').value = info.dateStr;
 
-                    // 5) 모달 띄우기
+                    // ❗️ 수정 모드에서 꺼진 속성들 되돌리기
+                    const fieldsToEnable = [
+                        leaveTypeEl,
+                        startDateEl,
+                        endDateEl,
+                        startTimeEl,
+                        endTimeEl,
+                        allDayCheck,
+                        holidayIncludeCheck
+                    ];
+                    fieldsToEnable.forEach(el => {
+                        if (!el) return;
+                        el.disabled = false;
+                        el.readOnly = false;
+                        el.classList.remove('select‑readonly');
+
+                    });
+
+                    // ❗️ currentIsHoliday도 반드시 false로 초기화
+                    currentIsHoliday = false;
+
+                    // (휴일 UI 숨기기)
+                    holidayIncludeGroup.style.display = 'none';
+                    holidayNotice.style.display = 'none';
+
+                    // UI 토글 함수를 한 번 더 호출
+                    onLeaveTypeChange();
+
                     formModal.show();
                 }
 
@@ -767,6 +794,36 @@
                 });
                 return true;
             }
+
+            // 1) 날짜 필드 실시간 유효성
+            [startDateEl, endDateEl].forEach(el => {
+                el.addEventListener('input', () => {
+                    if (startDateEl.value && endDateEl.value && startDateEl.value > endDateEl.value) {
+                        startDateEl.setCustomValidity('invalid-date');
+                        startDateEl.classList.add('is-invalid');
+                    } else {
+                        startDateEl.setCustomValidity('');
+                        startDateEl.classList.remove('is-invalid');
+                        endDateEl.setCustomValidity('');
+                        endDateEl.classList.remove('is-invalid');
+                    }
+                });
+            });
+
+            // 2) 시간 필드 실시간 유효성
+            [startTimeEl, endTimeEl].forEach(el => {
+                el.addEventListener('input', () => {
+                    validateDateTime();  // 내부에서 오류 리셋까지 처리됨
+                });
+            });
+
+            // 3) 모달 열릴 때 남아있는 invalid 초기화
+            eventFormModalEl.addEventListener('shown.bs.modal', () => {
+                [startDateEl, endDateEl, startTimeEl, endTimeEl].forEach(el => {
+                    el.setCustomValidity('');
+                    el.classList.remove('is-invalid');
+                });
+            });
 
             // 폼 제출 이벤트 잡기 - form 태그 안에 button 있으면 제출
             eventForm.addEventListener('submit', function (e) {


### PR DESCRIPTION
## 구현 사항 요약

### 일정 수정 로직 수정
  - 부분 휴일이 여러 일자에 걸쳐 있을 때에도 정상 동작하도록 수정
    - 부분 휴일 각 일자별로 근무시간 추출해서 그 시간이 기존 연차 일정이 있다면 적용 안되도록
    > 7/14 10:00 ~ 7/16 15:00 부분 휴일 일정 있다고 했을때 아래를 적용시킴
    > - 7/14은 10:00 ~ 17:00 까지 => 7/14일 하루 연차가 있었다고 하면 -> 08:00 ~ 10:00, 2시간만 사용한 것으로 변경 + 2시간 연차 사용 가능
    > - 7/15는 08:00 ~ 17:00 까지 => 7/15일 하루 연차가 있었다고 하면 -> 0시간 사용한 것으로 변경됨 + 연차 사용 불가
    > - 7/16는 08:00 ~ 15:00 까지 => 7/16일 하루 연차가 있었다고 하면 -> 15:00 ~ 17:00, 2시간만 사용한 것으로 변경됨 + 2시간 연차 사용 가능

### 일정 삭제 로직 수정
- 기념일 삭제 시
  - 해당 기념일 기간에 속한 연차 일정들 사용 시간 계산하여 업데이트
  > 7/14 10:00 ~ 7/16 15:00 부분 휴일 일정 삭제 시
    > - 7/14은 10:00 ~ 17:00 까지 삭제 => 7/14일 하루 연차가 있었다고 하면 -> 08:00 ~ 10:00, 2시간만 사용한 것으로 변경 + 2시간 연차 사용 가능  => **하루 연차 8시간 사용한 것으로 변경, 하루 언제든 연차 사용 가능**
    > - 7/15는 08:00 ~ 17:00 까지 => 7/15일 하루 연차가 있었다고 하면 -> 0시간 사용한 것으로 변경됨 + 연차 사용 불가 => **하루 연차 8시간 사용한 것으로 변경, 하루 언제든 연차 사용 가능**
    > - 7/16는 08:00 ~ 15:00 까지 => 7/16일 하루 연차가 있었다고 하면 -> 15:00 ~ 17:00, 2시간만 사용한 것으로 변경됨 + 2시간 연차 사용 가능 => **하루 연차 8시간 사용한 것으로 변경, 하루 언제든 연차 사용 가능**

## 목표 구현 사항

- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장 + **해당 일정이 얼마만큼의 연차를 소진한건지 double 컬럼 추가**
  - [x] `MEMBER` : 사용자 정보 저장
- [x] Spring Security 도입
  - [x] form_login 도입

- [x] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신
    - [x] (추가) 휴일 일정 변경, 휴일 여부 변경 등 삭제하고 다시 생성하도록 입구컷
    - [x] (추가) 일정 수정 시 수정하려는 일정이 휴일 등으로 연차 사용 시간이 0시간이라면 수정 튕겨내도록 수정
      - 사실 이미 삭제되었을 것

  - [x] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신
    - [x] (추가) 휴일 삭제할 경우 해당 기간에 속한 연차들 다시 불러와서 연차 기간 다시 계산하도록

- [x] 로그인 페이지

- [ ] 연차 사용 현황 페이지

- [x] 비밀번호 변경 페이지
- [x] 비밀번호 변경 API

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [ ] API 리팩토링
  - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [ ] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [x] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [x] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)
  - [ ] (추가) 파견직, 정규직 근무시간 다를 것 고려한 로직 수정(시작, 종료 시간)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현