### PR TITLE
연차 사용 현황 수정 & 약간의 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Querydsl ###
+/src/main/generated/
+
+### secret ###
+/src/main/resources/application-secret.yml

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,31 @@ java {
     }
 }
 
+// ───────────────────────────────────────────
+// Q‑클래스 생성 디렉토리 & clean 설정
+def generated = 'src/main/generated'
+
+// 1) JavaCompile 시 GENERATED 소스 디렉토리 지정
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(file(generated))
+}
+
+// 2) clean 시 GENERATED 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+
+// 3) QClass 생성 디렉토리를 Java 소스에 추가, 컴파일 대상 포함시킴
+sourceSets {
+    main {
+        java {
+            srcDirs += [ generated]
+        }
+    }
+}
+
+// ───────────────────────────────────────────
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -66,6 +91,11 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
+
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
+++ b/src/main/java/com/leavebridge/calendar/controller/CalendarController.java
@@ -1,6 +1,5 @@
 package com.leavebridge.calendar.controller;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -38,7 +37,7 @@ public class CalendarController {
 	 */
 	@GetMapping("/events/{year}/{month}")
 	public ResponseEntity<List<MonthlyEvent>> getUpcomingEvents(@PathVariable("year") Integer year,
-		@PathVariable("month") Integer month) throws Exception {
+		@PathVariable("month") Integer month) {
 		log.info("getUpcomingEvents :: year={}, month={}", year, month);
 		List<MonthlyEvent> events = calendarService.listMonthlyEvents(year, month);
 		return ResponseEntity.ok(events);
@@ -51,7 +50,8 @@ public class CalendarController {
 	public ResponseEntity<MonthlyEventDetailResponse> getEventDetail(@PathVariable("eventId") Long eventId,
 		@AuthenticationPrincipal CustomMemberDetails customMemberDetails) {
 		Member member = (customMemberDetails != null) ? customMemberDetails.getMember() : null;
-		log.info("getEventDetail :: eventId = {}, loginId = {}", eventId, member != null ? member.getLoginId() : "비회원 조회");
+		log.info("getEventDetail :: eventId = {}, loginId = {}", eventId,
+			member != null ? member.getLoginId() : "비회원 조회");
 		return ResponseEntity.ok(calendarService.getEventDetails(eventId, member));
 	}
 
@@ -60,7 +60,7 @@ public class CalendarController {
 	 **/
 	@PostMapping("/events")
 	public ResponseEntity<Void> createHolidays(@RequestBody CreateLeaveRequestDto createLeaveRequestDto,
-		@AuthenticationPrincipal(expression = "member") Member member) throws Exception {
+		@AuthenticationPrincipal(expression = "member") Member member) {
 		log.info("createHolidays :: createLeaveRequestDto = {}, login Member = {}", createLeaveRequestDto,
 			member.getLoginId());
 		calendarService.createTimedEvent(createLeaveRequestDto, member);
@@ -73,7 +73,7 @@ public class CalendarController {
 	@PatchMapping("/events/{eventId}")
 	public ResponseEntity<Void> updateHolidays(@PathVariable("eventId") Long eventId,
 		@RequestBody PatchLeaveRequestDto patchLeaveRequestDto,
-		@AuthenticationPrincipal(expression = "member") Member member) throws IOException {
+		@AuthenticationPrincipal(expression = "member") Member member) {
 		log.info("updateHolidays :: eventId={} patchLeaveRequestDto = {} login Id = {}", eventId, patchLeaveRequestDto,
 			member.getLoginId());
 		calendarService.updateEventDate(eventId, patchLeaveRequestDto, member);
@@ -85,7 +85,7 @@ public class CalendarController {
 	 */
 	@DeleteMapping("/events/{eventId}")
 	public ResponseEntity<Void> deleteHolidays(@PathVariable("eventId") Long eventId,
-		@AuthenticationPrincipal(expression = "member") Member member) throws IOException {
+		@AuthenticationPrincipal(expression = "member") Member member) {
 		log.info("deleteHolidays :: eventId={} member = {}", eventId, member.getLoginId());
 		calendarService.deleteEvent(eventId, member);
 		return ResponseEntity.ok().build();

--- a/src/main/java/com/leavebridge/calendar/service/GoogleCalendarAPIService.java
+++ b/src/main/java/com/leavebridge/calendar/service/GoogleCalendarAPIService.java
@@ -1,0 +1,93 @@
+package com.leavebridge.calendar.service;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.Event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleCalendarAPIService {
+	private final Calendar calendarClient;
+
+	@Value("${google.calendar-id}")
+	private String CALENDAR_ID;
+
+	// ─── 퍼블릭 API 메서드 ──────────────────────────────────────────────────────
+
+	public Event createGoogleCalendarEvent(Event event) {
+		return withGoogleCall(
+			() -> calendarClient.events().insert(CALENDAR_ID, event).execute(),
+			HttpStatus.BAD_REQUEST
+		);
+	}
+
+	public Event getGoogleCalendarEventByGoogleEventId(String eventId) {
+		return withGoogleCall(
+			() -> calendarClient.events().get(CALENDAR_ID, eventId).execute(),
+			HttpStatus.NOT_FOUND
+		);
+	}
+
+	public void patchGoogleCalendarEventByEventIdAndEvent(String eventId, Event event) {
+		// 람다에서 null을 반환
+		withGoogleCall(
+			() -> {
+				calendarClient.events().patch(CALENDAR_ID, eventId, event).execute();
+				return null;
+			},
+			HttpStatus.BAD_REQUEST
+		);
+	}
+
+	public void deleteGoogleCalendarEvent(String eventId) {
+		// 람다에서 null을 반환
+		withGoogleCall(
+			() -> {
+				calendarClient.events().delete(CALENDAR_ID, eventId).execute();
+				return null;
+			},
+			HttpStatus.NOT_FOUND
+		);
+	}
+
+	// ─── 공통 예외 처리 헬퍼 ──────────────────────────────────────────────────────
+
+	private <T> T withGoogleCall(Callable<T> googleCall, HttpStatus defaultStatus) {
+		try {
+			return googleCall.call();
+		} catch (GoogleJsonResponseException ex) {
+			int code = ex.getStatusCode();
+			String message = ex.getDetails().getMessage();
+			log.error("구글 캘린더 API 예외 발생 :: message = {}", message);
+			String reason = switch (code) {
+				case 400 -> "잘못된 요청입니다." + message;
+				case 401 -> "Google Token이 만료되었습니다. 관리자에게 문의하세요";
+				case 403 -> "Google Calendar API 한도 초과 등, 관리자에게 문의하세요";
+				case 404 -> "이미 삭제되었거나 리소스를 찾을 수 없습니다.";
+				case 409 -> "리소스 충돌이 발생했습니다.";
+				case 429 -> "요청이 너무 많습니다. 잠시 후 시도해주세요.";
+				default -> "Google Calendar 오류: " + ex.getStatusMessage();
+			};
+			throw new ResponseStatusException(HttpStatus.valueOf(code), reason, ex);
+		} catch (IOException ex) {
+			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "네트워크 오류로 Google Calendar에 연결할 수 없습니다.",
+				ex);
+		} catch (Exception ex) {
+			throw new ResponseStatusException(
+				defaultStatus, defaultStatus.getReasonPhrase(), ex
+			);
+		}
+	}
+}

--- a/src/main/java/com/leavebridge/config/QueryDslConfig.java
+++ b/src/main/java/com/leavebridge/config/QueryDslConfig.java
@@ -1,0 +1,22 @@
+package com.leavebridge.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+	private final EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+
+}

--- a/src/main/java/com/leavebridge/config/SecurityConfig.java
+++ b/src/main/java/com/leavebridge/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
 				// .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-				.requestMatchers("/", "/member/login", "/css/**", "/js/**").permitAll()
+				.requestMatchers("/", "/members/login", "/css/**", "/js/**").permitAll()
 				.requestMatchers("/api/*/calendar/events/*/*").permitAll() // 일정 조회
 				.requestMatchers("/member/login").permitAll() // 메인 페이지 누구나 가능
 				.requestMatchers("/usage").permitAll() // 연차 사용 현황 누구나 가능
@@ -33,7 +33,7 @@ public class SecurityConfig {
 			)
 			.logout(
 				logout -> logout
-					.logoutUrl("/member/logout")
+					.logoutUrl("/members/logout")
 					.logoutSuccessUrl("/")
 					.invalidateHttpSession(true)
 					.deleteCookies("JSESSIONID")
@@ -41,7 +41,7 @@ public class SecurityConfig {
 
 			.formLogin(
 				formLogin -> formLogin
-					.loginPage("/member/login")
+					.loginPage("/members/login")
 					.permitAll()
 					.defaultSuccessUrl("/", true)
 			)

--- a/src/main/java/com/leavebridge/global/CommonExceptionHandler.java
+++ b/src/main/java/com/leavebridge/global/CommonExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.leavebridge.global;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class CommonExceptionHandler {
+
+	@ExceptionHandler(ResponseStatusException.class)
+	public ResponseEntity<String> handleStatusEx(ResponseStatusException exception) {
+		log.error("익셉션 발생 :: ", exception);
+		return ResponseEntity.status(exception.getStatusCode()).body(exception.getReason());
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
+		log.error("익셉션 발생 :: ", exception);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+	}
+
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<String> handleAccessDenied(AccessDeniedException exception) {
+		log.warn("익셉션 발생 :: ", exception);
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한이 없습니다.");
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<String> handleParseError(HttpMessageNotReadableException exception) {
+		log.error("익셉션 발생 :: ", exception);
+		return ResponseEntity.badRequest().body("잘못된 요청 형식: " + exception.getMostSpecificCause().getMessage());
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<String> handleRuntimeException(RuntimeException exception) {
+		log.error("익셉션 발생 :: ", exception);
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exception.getMessage());
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<String> handleAll(Exception exception) {
+		log.error("익셉션 발생 ::", exception);
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 처리 중 오류가 발생했습니다.");
+	}
+}

--- a/src/main/java/com/leavebridge/member/controller/MemberController.java
+++ b/src/main/java/com/leavebridge/member/controller/MemberController.java
@@ -39,8 +39,8 @@ public class MemberController {
 	}
 
 	@GetMapping("/{memberId}/used-leaves")
-	public ResponseEntity<MemberUsedLeavesResponseDto> getUsedLeaves(@PathVariable @Schema(description = "사용자 id", example = "3") Long memberId,
-		@RequestParam @Schema(description = "조회할 년도", example = "2025") Integer year, @PageableDefault(size = 20, page = 0) Pageable pageable) {
+	public ResponseEntity<MemberUsedLeavesResponseDto> getUsedLeaves(@PathVariable("memberId") @Schema(description = "사용자 id", example = "3") Long memberId,
+		@RequestParam(name="year") @Schema(description = "조회할 년도", example = "2025") Integer year, @PageableDefault(size = 20, page = 0) Pageable pageable) {
 		return ResponseEntity.ok(memberService.getMemberUsedLeaves(memberId, year, pageable));
 	}
 

--- a/src/main/java/com/leavebridge/member/controller/MemberController.java
+++ b/src/main/java/com/leavebridge/member/controller/MemberController.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping("/api/v1/member")
+@RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 @Slf4j
 public class MemberController {
@@ -32,7 +32,7 @@ public class MemberController {
 		return ResponseEntity.ok(memberService.getMemberUsedLeaves());
 	}
 
-	@PostMapping("/change-passwords")
+	@PatchMapping("/me/password")
 	public ResponseEntity<Void> changePassword(
 		@RequestBody @Valid RequestChangePasswordRequest requestChangePasswordRequest,
 		@AuthenticationPrincipal CustomMemberDetails customMemberDetails) {

--- a/src/main/java/com/leavebridge/member/controller/MemberController.java
+++ b/src/main/java/com/leavebridge/member/controller/MemberController.java
@@ -2,19 +2,25 @@ package com.leavebridge.member.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.leavebridge.member.dto.FindMemberListReponseDto;
 import com.leavebridge.member.dto.MemberUsedLeavesResponseDto;
 import com.leavebridge.member.dto.RequestChangePasswordRequest;
 import com.leavebridge.member.entitiy.CustomMemberDetails;
 import com.leavebridge.member.service.MemberService;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,9 +33,15 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@GetMapping("/used-leaves")
-	public ResponseEntity<List<MemberUsedLeavesResponseDto>> getUsedLeaves() {
-		return ResponseEntity.ok(memberService.getMemberUsedLeaves());
+	@GetMapping
+	public ResponseEntity<List<FindMemberListReponseDto>> findMemberList() {
+		return ResponseEntity.ok(memberService.findMemberListForUsage());
+	}
+
+	@GetMapping("/{memberId}/used-leaves")
+	public ResponseEntity<MemberUsedLeavesResponseDto> getUsedLeaves(@PathVariable @Schema(description = "사용자 id", example = "3") Long memberId,
+		@RequestParam @Schema(description = "조회할 년도", example = "2025") Integer year, @PageableDefault(size = 20, page = 0) Pageable pageable) {
+		return ResponseEntity.ok(memberService.getMemberUsedLeaves(memberId, year, pageable));
 	}
 
 	@PatchMapping("/me/password")

--- a/src/main/java/com/leavebridge/member/controller/MemberViewController.java
+++ b/src/main/java/com/leavebridge/member/controller/MemberViewController.java
@@ -12,13 +12,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MemberViewController {
 
-	@GetMapping("/member/login")
+	@GetMapping("/members/login")
 	public String login() {
 		return "member/login";
 	}
 
-	@GetMapping("/member/chaange-password")
+	@GetMapping("/members/me/password")
 	public String changePassword() {
 		return "member/change_password";
+	}
+
+	@GetMapping("/members/leaves/usage")
+	public String membersLeavesUsage() {
+		return "member/leaves_usage";
 	}
 }

--- a/src/main/java/com/leavebridge/member/dto/FindMemberListReponseDto.java
+++ b/src/main/java/com/leavebridge/member/dto/FindMemberListReponseDto.java
@@ -1,0 +1,18 @@
+package com.leavebridge.member.dto;
+
+import com.leavebridge.member.entitiy.Member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record FindMemberListReponseDto(
+	@Schema(description = "사용자 Id", example = "3")
+	Long memberId,
+	@Schema(description = "사용자 이름", example = "박철현")
+	String memberName
+) {
+	public static FindMemberListReponseDto of(Member member) {
+		return FindMemberListReponseDto.builder().memberId(member.getId()).memberName(member.getName()).build();
+	}
+}

--- a/src/main/java/com/leavebridge/member/dto/LeaveDetailDto.java
+++ b/src/main/java/com/leavebridge/member/dto/LeaveDetailDto.java
@@ -1,8 +1,8 @@
 package com.leavebridge.member.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
-import com.leavebridge.calendar.entity.LeaveAndHoliday;
 import com.leavebridge.calendar.enums.LeaveType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,25 +16,23 @@ public record LeaveDetailDto(
 	String title,
 	@Schema(description = "일정 설명", example = "박철현 연차")
 	String description,
-	@Schema(description = "일정 시작일", example = "2025-=07-01T12:00:00")
-	LocalDateTime start,
-	@Schema(description = "일정 종료일", example = "2025-=07-01T15:00:00")
-	LocalDateTime end,
+	@Schema(description = "일정 시작일", example = "2025-=07-01")
+	LocalDate startDate,
+	@Schema(description = "일정 시작 시간", example = "12:00:00")
+	LocalTime startTime,
+	@Schema(description = "일정 종료일", example = "2025-=07-03")
+	LocalDate endDate,
+	@Schema(description = "일정 종료 시간", example = "12:00:00")
+	LocalTime endTime,
 	@Schema(description = "해당 일자에서 연차 사용일", example = "0.5")
 	double usedDays,
+	@Schema(description = "비고", example = "부분 휴일으로 240분 연차 미차감")
+	String comment,
 	@Schema(description = "연차 타입")
-	LeaveType leaveType
+	String leaveType
 ) {
-	public static LeaveDetailDto of(LeaveAndHoliday leaveAndHoliday, double usedDays) {
-
-		return LeaveDetailDto.builder()
-			.id(leaveAndHoliday.getId())
-			.title(leaveAndHoliday.getTitle())
-			.description(leaveAndHoliday.getDescription())
-			.start(LocalDateTime.of(leaveAndHoliday.getStartDate(), leaveAndHoliday.getStarTime()))
-			.end(LocalDateTime.of(leaveAndHoliday.getEndDate(), leaveAndHoliday.getEndTime()))
-			.usedDays(usedDays)
-			.leaveType(leaveAndHoliday.getLeaveType())
-			.build();
+	public LeaveDetailDto(Long id, String title, String description, LocalDate startDate, LocalTime startTime,
+		LocalDate endDate, LocalTime endTime, double usedDays, String comment, LeaveType leaveType) {
+		this(id, title, description, startDate, startTime, endDate, endTime, usedDays, comment, leaveType.getType());
 	}
 }

--- a/src/main/java/com/leavebridge/member/dto/MemberUsedLeavesResponseDto.java
+++ b/src/main/java/com/leavebridge/member/dto/MemberUsedLeavesResponseDto.java
@@ -1,36 +1,37 @@
 package com.leavebridge.member.dto;
 
-import java.util.List;
-
-import com.leavebridge.member.entitiy.Member;
+import org.springframework.data.web.PagedModel;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
-public record MemberUsedLeavesResponseDto(
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberUsedLeavesResponseDto {
 	@Schema(description = "member Id", example = "3")
-	Long memberId,
+	Long memberId;
 	@Schema(description = "member 이름", example = "박철현")
-	String memberName,
-	@Schema(description = "총 잔여 연차", example = "12.0")
-	double totalCount,     // 12
+	String memberName;
+	@Schema(description = "총 부여 연차", example = "15.0")
+	double totalCount;
 	@Schema(description = "총 사용 연차", example = "3.5")
-	double usedDays,
+	double totalUsedDays;
 	@Schema(description = "총 남은 연차", example = "3.5")
-	double remainingDays,  // 7.5
+	double remainingDays;
 	@Schema(description = "개인별 연차 사용 현황 목록")
-	List<LeaveDetailDto> leaveDetails
-) {
-	public static MemberUsedLeavesResponseDto of(Member member, double totalCount, double usedDays, double remainingDays,
-		List<LeaveDetailDto> leaveDetails) {
-		return MemberUsedLeavesResponseDto.builder()
-			.memberId(member.getId())
-			.memberName(member.getName())
-			.totalCount(totalCount)
-			.usedDays(usedDays)
-			.remainingDays(remainingDays)
-			.leaveDetails(leaveDetails)
-			.build();
+	PagedModel<LeaveDetailDto> leaveDetails;
+
+	public MemberUsedLeavesResponseDto(Long memberId, String memberName, double totalCount, double totalUsedDays) {
+		this(memberId, memberName, totalCount, totalUsedDays, totalCount - totalUsedDays, null);
 	}
+
+	public void updateLeaveDetails(PagedModel<LeaveDetailDto> leaveDetails) {
+		this.leaveDetails = leaveDetails;
+	}
+
 }

--- a/src/main/java/com/leavebridge/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/leavebridge/member/repository/MemberQueryRepository.java
@@ -1,0 +1,98 @@
+package com.leavebridge.member.repository;
+
+import static com.leavebridge.calendar.entity.QLeaveAndHoliday.*;
+import static com.leavebridge.member.entitiy.QMember.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.data.web.PagedModel;
+import org.springframework.stereotype.Repository;
+
+import com.leavebridge.member.dto.FindMemberListReponseDto;
+import com.leavebridge.member.dto.LeaveDetailDto;
+import com.leavebridge.member.dto.MemberUsedLeavesResponseDto;
+import com.leavebridge.member.entitiy.Member;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	/**
+	 * 1) 전체 통계용 DTO(MemberUsedLeavesResponseDto) Projections
+	 */
+	public MemberUsedLeavesResponseDto fetchMemberStats(Member targetMember, int year) {
+		return queryFactory
+			.select(Projections.constructor(MemberUsedLeavesResponseDto.class,
+				Expressions.constant(targetMember.getId()),
+				Expressions.constant(targetMember.getName()),
+				Expressions.constant(15.0),
+				leaveAndHoliday.usedLeaveHours.sum()
+			))
+			.from(leaveAndHoliday)
+			.where(
+				leaveAndHoliday.member.id.eq(targetMember.getId())
+					.and(leaveAndHoliday.startDate.year().eq(year))
+			)
+			.fetchOne();
+	}
+
+	/**
+	 * 2) 페이징된 LeaveDetailDto 페이지 조회
+	 */
+	public PagedModel<LeaveDetailDto> findLeaveDetails(Member targetMember, Integer year, Pageable pageable) {
+		List<LeaveDetailDto> content = queryFactory
+			.select(Projections.constructor(LeaveDetailDto.class,
+				leaveAndHoliday.id,
+				leaveAndHoliday.title,
+				leaveAndHoliday.description,
+				leaveAndHoliday.startDate,
+				leaveAndHoliday.starTime,
+				leaveAndHoliday.endDate,
+				leaveAndHoliday.endTime,
+				leaveAndHoliday.usedLeaveHours,
+				leaveAndHoliday.comment,
+				leaveAndHoliday.leaveType
+			))
+			.from(leaveAndHoliday)
+			.where(
+				leaveAndHoliday.member.id.eq(targetMember.getId())
+					.and(leaveAndHoliday.startDate.year().eq(year))
+			)
+			.orderBy(leaveAndHoliday.startDate.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		// total count
+		JPAQuery<Long> total = queryFactory.select(leaveAndHoliday.count())
+			.from(leaveAndHoliday)
+			.where(
+				leaveAndHoliday.member.id.eq(targetMember.getId())
+					.and(leaveAndHoliday.startDate.year().eq(year))
+			);
+
+		// content paged
+		return new PagedModel<>(PageableExecutionUtils.getPage(content, pageable, total::fetchOne));
+	}
+
+	public List<FindMemberListReponseDto> findAllMembersNotIncludeAdmin() {
+		return queryFactory.select(Projections.constructor(FindMemberListReponseDto.class,
+				member.id,
+				member.name))
+			.from(member)
+			.where(
+				member.id.ne(4L)
+			)
+			.fetch();
+	}
+}

--- a/src/main/java/com/leavebridge/member/repository/MemberRepository.java
+++ b/src/main/java/com/leavebridge/member/repository/MemberRepository.java
@@ -1,6 +1,5 @@
 package com.leavebridge.member.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,15 +12,7 @@ import com.leavebridge.member.entitiy.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByLoginId(String username);
 
-	@Query("""
-        select distinct m
-        from Member m
-        left join fetch m.leaveAndHolidays l
-        where m.id != 4
-        """)
-	List<Member> findAllWithLeaves();
-
 	@Modifying
 	@Query("UPDATE Member m SET m.password = :newPassword WHERE m.id = :memberId")
-	void updatePassword(@Param("memberId")Long memberId, @Param("newPassword") String newPassword);
+	void updatePassword(@Param("memberId") Long memberId, @Param("newPassword") String newPassword);
 }

--- a/src/main/java/com/leavebridge/member/repository/MemberRepository.java
+++ b/src/main/java/com/leavebridge/member/repository/MemberRepository.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.leavebridge.member.entitiy.Member;
 
@@ -18,4 +20,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         where m.id != 4
         """)
 	List<Member> findAllWithLeaves();
+
+	@Modifying
+	@Query("UPDATE Member m SET m.password = :newPassword WHERE m.id = :memberId")
+	void updatePassword(@Param("memberId")Long memberId, @Param("newPassword") String newPassword);
 }

--- a/src/main/java/com/leavebridge/member/service/MemberSecurityService.java
+++ b/src/main/java/com/leavebridge/member/service/MemberSecurityService.java
@@ -1,10 +1,10 @@
 package com.leavebridge.member.service;
 
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.leavebridge.member.entitiy.CustomMemberDetails;
 import com.leavebridge.member.entitiy.Member;
@@ -21,6 +21,7 @@ public class MemberSecurityService implements UserDetailsService {
 	private final MemberRepository memberRepository;
 
 	@Override
+	@Transactional(readOnly = true)
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 		log.info("loadUserByUsername :: {}", username);
 		Member member = memberRepository.findByLoginId(username).orElseThrow(

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -241,30 +241,6 @@
             return `${year}-${month}-${day}`;  // 템플릿 리터럴로 최종 문자열 조합
         }
 
-        /*
-            좀 더 친숙한 시간 표현대로 변경하는 함수
-         */
-        function formatKoreanDateTime(dateStr, timeStr) {
-            // ISO 문자열로 합치기
-            // timeStr이 초(sec)까지 포함하지 않을 수도 있어서 pad 보장
-            const normalizedTime = timeStr.length === 5
-                ? `${timeStr}:00`
-                : timeStr;
-            const isoString = `${dateStr}T${normalizedTime}`;
-
-            // Date 객체 생성 (로컬 타임존 기반)
-            const dt = new Date(isoString);
-
-            // Intl.DateTimeFormat 으로 한 번에 포맷
-            return new Intl.DateTimeFormat('ko-KR', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-                hour: 'numeric',
-                minute: 'numeric',
-                hour12: true
-            }).format(dt);
-        }
 
         function onModifyToggleAllDayChange() {
             const allDayCheck = document.getElementById('allDayCheck');

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -89,30 +89,62 @@
 <!-- 공통 스크립트 -->
 <script>
 
+    /*
+    좀 더 친숙한 시간 표현대로 변경하는 함수
+ */
+    function formatKoreanDateTime(dateStr, timeStr) {
+        // ISO 문자열로 합치기
+        // timeStr이 초(sec)까지 포함하지 않을 수도 있어서 pad 보장
+        const normalizedTime = timeStr.length === 5
+            ? `${timeStr}:00`
+            : timeStr;
+        const isoString = `${dateStr}T${normalizedTime}`;
+
+        // Date 객체 생성 (로컬 타임존 기반)
+        const dt = new Date(isoString);
+
+        // Intl.DateTimeFormat 으로 한 번에 포맷
+        return new Intl.DateTimeFormat('ko-KR', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            hour12: true
+        }).format(dt);
+    }
+
+
     // fetch 요청 리다이렉트 적용되도록 오버라이드
     (() => {
-        // 원본 fetch 저장
         const _fetch = window.fetch;
-
-        // 전역 fetch 오버라이드
         window.fetch = function(input, init = {}) {
-            // credentials: 'include' 를 기본값으로 추가(쿠키 인증을 위해)
             init.credentials = init.credentials || 'include';
-
             return _fetch(input, init)
                 .then(response => {
-                    // 401 Unauthorized 또는 리다이렉트 감지
+                    // 1) 인증 실패나 리다이렉트
                     if (response.status === 401 || response.redirected) {
-                        // 로그인 페이지로 전체 네비게이션
                         window.location.href = '/members/login';
-                        // 이후 체인 중단
                         return Promise.reject(new Error('Redirecting to login'));
                     }
+
+                    // 2) 400~499 클라이언트 에러
+                    if (response.status >= 400 && response.status < 500) {
+                        response.clone().text().then(text => {
+                            showToast(`요청 오류 (${response.status}): ${text || response.statusText}`, 'error');
+                        });
+                        // 필요에 따라 에러를 던지거나, 응답 객체를 그대로 반환할 수도 있음
+                    }
+                    // 3) 500~599 서버 에러
+                    else if (response.status >= 500) {
+                        showToast(`서버 오류 (${response.status}): 잠시 후 다시 시도해주세요.`, 'error');
+                    }
+
                     return response;
                 })
                 .catch(err => {
-                    // 네트워크 오류 등도 여기서 처리 가능
                     console.error('Global fetch error:', err);
+                    showToast(`네트워크 오류: ${err.message}`, 'error');
                     throw err;
                 });
         };

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -104,7 +104,7 @@
                     // 401 Unauthorized 또는 리다이렉트 감지
                     if (response.status === 401 || response.redirected) {
                         // 로그인 페이지로 전체 네비게이션
-                        window.location.href = '/member/login';
+                        window.location.href = '/members/login';
                         // 이후 체인 중단
                         return Promise.reject(new Error('Redirecting to login'));
                     }

--- a/src/main/resources/templates/common/navbar.html
+++ b/src/main/resources/templates/common/navbar.html
@@ -6,12 +6,12 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" th:href="@{/usage}">연차사용현황</a></li>
-        <li class="nav-item"><a class="nav-link" th:href="@{/member/login}" th:if="${#authorization.expression('isAnonymous()')}">로그인</a></li>
+        <li class="nav-item"><a class="nav-link" th:href="@{/members/leaves/usage}">연차사용현황</a></li>
+        <li class="nav-item"><a class="nav-link" th:href="@{/members/login}" th:if="${#authorization.expression('isAnonymous()')}">로그인</a></li>
         <li class="nav-item"><a class="nav-link" href="#" th:if="${#authorization.expression('isAuthenticated()')}" onclick="this.nextElementSibling.submit();">로그아웃</a>
-          <form th:action="@{/member/logout}" th:method="post" hidden></form>
+          <form th:action="@{/members/logout}" th:method="post" hidden></form>
         </li>
-        <li class="nav-item"><a class="nav-link" href="/member/chaange-password" th:if="${#authorization.expression('isAuthenticated()')}">비밀번호 변경</a></li>
+        <li class="nav-item"><a class="nav-link" href="/members/me/password" th:if="${#authorization.expression('isAuthenticated()')}">비밀번호 변경</a></li>
       </ul>
     </div>
   </div>

--- a/src/main/resources/templates/member/change_password.html
+++ b/src/main/resources/templates/member/change_password.html
@@ -54,8 +54,8 @@
             };
 
             try {
-                const res = await fetch('/api/v1/member/change-passwords', {
-                    method: form.method.toUpperCase(), // "POST"
+                const res = await fetch('/api/v1/members/me/password', {
+                    method: "PATCH",
                     headers: requestHeaders,
                     body: JSON.stringify(data)
                 });

--- a/src/main/resources/templates/member/leaves_usage.html
+++ b/src/main/resources/templates/member/leaves_usage.html
@@ -3,137 +3,349 @@
       layout:decorate="~{common/layout}">
 <head>
     <title>연차 사용 현황</title>
-</head>
+    <style>
+        /* 사용자 목록: 5열 고정 */
+        #user-list {
+            display: grid;
+            grid-template-columns: repeat(5, 1fr);
+            gap: 0.5rem;
+            width: 100%;
+        }
 
-<div layout:fragment="content">
-        <h1 class="mb-4">연차 사용 현황</h1>
+        #user-list .user-btn {
+            text-align: center;
+        }
 
-        <div class="row">
-            <!-- 사용자 목록 (List Group) -->
-            <div>
-                <h5>사용자 목록</h5>
-                <div id="user-list" class="d-flex flex-row flex-wrap">
-                    <!-- JS로 채워집니다 -->
-                </div>
-            </div>
+        #user-list .user-btn button {
+            width: 100%;
+            white-space: nowrap;
+        }
 
-            <!-- 상세 테이블 영역 -->
-            <div>
-                <div id="usage-detail" class="card" style="display:none;">
-                    <div class="card-body">
-                        <h5 class="card-title">
-                            연차 사용 현황: <span id="selected-user-name"></span>
-                        </h5>
-                        <p class="card-text mb-1">
-                            <strong>총 잔여 연차:</strong> <span id="total-count"></span> 일
-                        </p>
-                        <p class="card-text mb-3">
-                            <strong>총 사용 연차:</strong> <span id="used-days"></span> 일<br>
-                            <strong>총 남은 연차:</strong> <span id="remaining-days"></span> 일
-                        </p>
+        /* 년도 검색 영역 */
+        .year-search-container {
+            background-color: #f8f9fa;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            margin-bottom: 1rem;
+        }
 
-                        <div class="table-responsive">
-                            <table class="table table-striped table-hover align-middle">
-                                <thead class="table-light">
-                                <tr>
-                                    <th scope="col">순번</th>
-                                    <th scope="col">제목</th>
-                                    <th scope="col">설명</th>
-                                    <th scope="col">시작</th>
-                                    <th scope="col">종료</th>
-                                    <th scope="col">사용일수</th>
-                                    <th scope="col">타입</th>
-                                </tr>
-                                </thead>
-                                <tbody id="detail-body"></tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+        .year-search-controls {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
 
-    <script>
-        let membersData = [];
+        .custom-year-input {
+            display: none;
+        }
 
-        document.addEventListener('DOMContentLoaded', () => {
-            const listGroup = document.getElementById('user-list');
+        .custom-year-input.show {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
 
-            // 1) 전체 사용자 API 호출
-            fetch('/api/v1/member/used-leaves')
-                .then(res => { if (!res.ok) throw new Error(); return res.json(); })
-                .then(users => {
-                    membersData = users;
+        /* 페이징 네비게이션 (간단 버전) */
+        #page-info {
+            margin-top: 0.5rem;
+            font-size: 0.9rem;
+        }
 
-                    // 2) List Group 아이템 생성
-                    users.forEach(user => {
-                        const btn = document.createElement('button');
-                        btn.type        = 'button';
-                        btn.className   = 'btn btn-outline-primary mx-2 my-2';  // 좌우 마진 mx-2, 상하 마진 my-2
-                        btn.style.whiteSpace = 'nowrap';
-                        btn.textContent = user.memberName;
-                        btn.dataset.id  = user.memberId;
-                        btn.addEventListener('click', onUserClick);
-                        listGroup.appendChild(btn);
-                    });
-                })
-                .catch(err => console.error(err));
-        });
+        #page-controls button {
+            margin: 0 0.25rem;
+        }
 
-        function onUserClick() {
-            // 1) 기존 active 제거
-            document
-                .querySelectorAll('#user-list button.active')
-                .forEach(btn => btn.classList.remove('active'));
-
-            // 2) 클릭된 버튼에만 active 추가
-            this.classList.add('active');
-
-            const memberId   = this.dataset.id;
-            const memberName = this.textContent;
-            document.getElementById('selected-user-name').textContent = memberName;
-
-            const userRecord = membersData.find(u => String(u.memberId) === memberId);
-            if (userRecord.leaveDetails) {
-                renderDetails(userRecord);
-            } else {
-                fetch(`/api/member/leave/usage?memberId=${memberId}`)
-                    .then(res => { if (!res.ok) throw new Error(); return res.json(); })
-                    .then(data => {
-                        Object.assign(userRecord, data);
-                        renderDetails(userRecord);
-                    })
-                    .catch(err => console.error(err));
+        /* 반응형 그리드 조정 */
+        @media (max-width: 1200px) {
+            #user-list {
+                grid-template-columns: repeat(4, 1fr);
             }
         }
 
-        function renderDetails(user) {
-            document.getElementById('total-count').textContent    = user.totalCount;
-            document.getElementById('used-days').textContent      = user.usedDays;
-            document.getElementById('remaining-days').textContent = user.remainingDays;
+        @media (max-width: 768px) {
+            #user-list {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
 
-            const tbody = document.getElementById('detail-body');
-            tbody.innerHTML = '';
+        @media (max-width: 576px) {
+            #user-list {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+    </style>
+</head>
 
-            user.leaveDetails.forEach((item, idx) => {
-                const tr = document.createElement('tr');
-                [
-                    idx + 1,
-                    item.title,
-                    item.description,
-                    item.start.replace('T',' '),
-                    item.end.replace('T',' '),
-                    item.usedDays,
-                    item.leaveType
-                ].forEach(text => {
-                    const td = document.createElement('td');
-                    td.textContent = text;
-                    tr.append(td);
+<div layout:fragment="content">
+    <h1 class="mb-4">연차 사용 현황</h1>
+
+    <div class="row">
+        <!-- 사용자 목록 (Grid Layout) -->
+        <div class="container-fluid py-4">
+            <h5 class="mb-3">사용자 목록</h5>
+            <div id="user-list">
+                <!-- JS로 채워집니다 -->
+            </div>
+        </div>
+
+        <!-- 상세 테이블 영역 -->
+        <div>
+            <div id="usage-detail" class="card" style="display:none; margin-top:1rem;">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h5 class="card-title mb-0">
+                            연차 사용 현황: <span id="selected-user-name"></span>
+                        </h5>
+                        <small class="text-muted">
+                            <strong>조회 년도:</strong> <span id="current-year-display"></span>년
+                        </small>
+                    </div>
+
+                    <!-- 년도 검색 영역 -->
+                    <div class="year-search-container mb-3">
+                        <h6 class="mb-2">조회 년도 변경</h6>
+                        <div class="year-search-controls">
+                            <select id="year-select" class="form-select" style="width: auto;">
+                                <option value="2025">2025년</option>
+                                <option value="2026">2026년</option>
+                                <option value="2027">2027년</option>
+                                <option value="2028">2028년</option>
+                                <option value="2029">2029년</option>
+                                <option value="2030">2030년</option>
+                                <option value="custom">직접입력</option>
+                            </select>
+
+                            <div id="custom-year-input" class="custom-year-input">
+                                <input type="number" id="custom-year" class="form-control" placeholder="년도 입력" style="width: 120px;" min="2020" max="2099">
+                                <button type="button" id="custom-search-btn" class="btn btn-primary">검색</button>
+                            </div>
+
+                            <button type="button" id="year-search-btn" class="btn btn-primary">검색</button>
+                        </div>
+                    </div>
+                    <p class="card-text mb-1">
+                        <strong>총 잔여 연차:</strong> <span id="total-count"></span> 일
+                    </p>
+                    <p class="card-text mb-3">
+                        <strong>총 사용 연차:</strong> <span id="used-days"></span> 일<br>
+                        <strong>총 남은 연차:</strong> <span id="remaining-days"></span> 일
+                    </p>
+
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover align-middle text-center">
+                            <thead class="table-light">
+                            <tr>
+                                <th scope="col">순번</th>
+                                <th scope="col">제목</th>
+                                <th scope="col">설명</th>
+                                <th scope="col">시작</th>
+                                <th scope="col">종료</th>
+                                <th scope="col">사용일수</th>
+                                <th scope="col">타입</th>
+                            </tr>
+                            </thead>
+                            <tbody id="detail-body"></tbody>
+                        </table>
+                    </div>
+
+                    <!-- 간단 페이징 정보 -->
+                    <div id="page-info"></div>
+                    <div id="page-controls">
+                        <button id="prev-page" class="btn btn-outline-secondary btn-sm">이전</button>
+                        <button id="next-page" class="btn btn-outline-secondary btn-sm">다음</button>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let members = [];
+        let currentMemberId = null;
+        let currentYear = new Date().getFullYear();
+        let currentPage = 0;
+        const pageSize = 10;
+
+        document.addEventListener('DOMContentLoaded', () => {
+            // 현재 년도로 초기화
+            document.getElementById('year-select').value = currentYear;
+            document.getElementById('current-year-display').textContent = currentYear;
+
+            // 1) 멤버 목록 로드
+            fetch('/api/v1/members')
+                .then(r => r.json())
+                .then(list => {
+                    members = list;
+                    renderMemberList();
                 });
-                tbody.append(tr);
+
+            // 2) 페이징 버튼
+            document.getElementById('prev-page').addEventListener('click', () => {
+                if (currentPage > 0) {
+                    currentPage--;
+                    loadUsage(currentMemberId);
+                }
+            });
+            document.getElementById('next-page').addEventListener('click', () => {
+                // 다음 페이지 존재 여부는 loadUsage에서 체크
+                currentPage++;
+                loadUsage(currentMemberId);
             });
 
-            document.getElementById('usage-detail').style.display = 'block';
+            // 3) 년도 선택 이벤트
+            document.getElementById('year-select').addEventListener('change', function() {
+                const customInput = document.getElementById('custom-year-input');
+                const yearSearchBtn = document.getElementById('year-search-btn');
+
+                if (this.value === 'custom') {
+                    customInput.classList.add('show');
+                    yearSearchBtn.style.display = 'none';
+                } else {
+                    customInput.classList.remove('show');
+                    yearSearchBtn.style.display = 'inline-block';
+                }
+            });
+
+            // 4) 년도 검색 버튼
+            document.getElementById('year-search-btn').addEventListener('click', () => {
+                const selectedYear = document.getElementById('year-select').value;
+                if (selectedYear !== 'custom') {
+                    searchByYear(parseInt(selectedYear));
+                }
+            });
+
+            // 5) 직접입력 검색 버튼
+            document.getElementById('custom-search-btn').addEventListener('click', () => {
+                const customYear = document.getElementById('custom-year').value;
+
+                // 숫자가 아닌 문자가 포함되어 있는지 검사
+                if (!/^\d+$/.test(customYear)) {
+                    alert('숫자만 입력해주세요');
+                    return;
+                }
+
+                const yearNum = parseInt(customYear);
+                if (customYear && yearNum >= 2020 && yearNum <= 2099) {
+                    searchByYear(yearNum);
+                } else {
+                    alert('올바른 년도를 입력해주세요 (2020-2099)');
+                }
+            });
+
+            // 6) 직접입력 엔터키 처리
+            document.getElementById('custom-year').addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') {
+                    document.getElementById('custom-search-btn').click();
+                }
+            });
+        });
+
+        function searchByYear(year) {
+            currentYear = year;
+            currentPage = 0;
+            document.getElementById('current-year-display').textContent = year;
+
+            if (currentMemberId) {
+                loadUsage(currentMemberId);
+            }
+        }
+
+        function renderMemberList() {
+            const listContainer = document.getElementById('user-list');
+            listContainer.innerHTML = '';
+
+            members.forEach(m => {
+                const div = document.createElement('div');
+                div.className = 'user-btn';
+
+                const btn = document.createElement('button');
+                btn.type        = 'button';
+                btn.className   = 'btn btn-outline-primary w-100 text-truncate';
+                btn.textContent = m.memberName;
+                btn.dataset.id  = m.memberId;
+                btn.addEventListener('click', onMemberClick);
+
+                div.appendChild(btn);
+                listContainer.appendChild(div);
+            });
+        }
+
+        function onMemberClick(e) {
+            // Active 처리
+            document.querySelectorAll('#user-list button.active')
+                .forEach(b => b.classList.remove('active'));
+            e.currentTarget.classList.add('active');
+
+            // 멤버 변경
+            currentMemberId = e.currentTarget.dataset.id;
+            currentPage = 0;
+            document.getElementById('selected-user-name').textContent = e.currentTarget.textContent;
+            loadUsage(currentMemberId);
+        }
+
+        function loadUsage(memberId) {
+            if (!memberId) return;
+            fetch(`/api/v1/members/${memberId}/used-leaves?year=${currentYear}&page=${currentPage}&size=${pageSize}`)
+                .then(r => r.json())
+                .then(dto => {
+                    // 통계
+                    document.getElementById('total-count').textContent    = dto.totalCount;
+                    document.getElementById('used-days').textContent      = dto.totalUsedDays ?? dto.usedDays;
+                    document.getElementById('remaining-days').textContent = dto.remainingDays;
+
+                    // 상세 목록
+                    const tbody = document.getElementById('detail-body');
+                    tbody.innerHTML = '';
+                    dto.leaveDetails.content.forEach((item, idx) => {
+                        const tr = document.createElement('tr');
+                        [
+                            idx + 1 + currentPage * pageSize,
+                            item.title,
+                            item.description,
+                            item.startDate + ' ' + item.startTime,
+                            item.endDate   + ' ' + item.endTime,
+                            item.usedDays,
+                            item.leaveType
+                        ].forEach(text => {
+                            const td = document.createElement('td');
+                            td.textContent = text;
+                            tr.appendChild(td);
+                        });
+                        tbody.appendChild(tr);
+                    });
+
+                    // 페이지 정보 및 버튼 상태 업데이트
+                    const pg = dto.leaveDetails.page;
+                    document.getElementById('page-info').textContent =
+                        `페이지 ${pg.number + 1} / ${pg.totalPages} (전체 ${pg.totalElements}건)`;
+
+                    // 페이징 버튼 활성화/비활성화
+                    const prevBtn = document.getElementById('prev-page');
+                    const nextBtn = document.getElementById('next-page');
+
+                    // 이전 버튼: 첫 페이지가 아닐 때만 활성화
+                    if (pg.number === 0) {
+                        prevBtn.disabled = true;
+                        prevBtn.classList.add('disabled');
+                    } else {
+                        prevBtn.disabled = false;
+                        prevBtn.classList.remove('disabled');
+                    }
+
+                    // 다음 버튼: 마지막 페이지가 아닐 때만 활성화
+                    if (pg.number >= pg.totalPages - 1) {
+                        nextBtn.disabled = true;
+                        nextBtn.classList.add('disabled');
+                    } else {
+                        nextBtn.disabled = false;
+                        nextBtn.classList.remove('disabled');
+                    }
+
+                    // 상세 영역 보이기
+                    document.getElementById('usage-detail').style.display = 'block';
+                });
         }
     </script>
 </div>

--- a/src/main/resources/templates/member/leaves_usage.html
+++ b/src/main/resources/templates/member/leaves_usage.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{common/layout}">
+<head>
+    <title>연차 사용 현황</title>
+</head>
+
+<div layout:fragment="content">
+        <h1 class="mb-4">연차 사용 현황</h1>
+
+        <div class="row">
+            <!-- 사용자 목록 (List Group) -->
+            <div>
+                <h5>사용자 목록</h5>
+                <div id="user-list" class="d-flex flex-row flex-wrap">
+                    <!-- JS로 채워집니다 -->
+                </div>
+            </div>
+
+            <!-- 상세 테이블 영역 -->
+            <div>
+                <div id="usage-detail" class="card" style="display:none;">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            연차 사용 현황: <span id="selected-user-name"></span>
+                        </h5>
+                        <p class="card-text mb-1">
+                            <strong>총 잔여 연차:</strong> <span id="total-count"></span> 일
+                        </p>
+                        <p class="card-text mb-3">
+                            <strong>총 사용 연차:</strong> <span id="used-days"></span> 일<br>
+                            <strong>총 남은 연차:</strong> <span id="remaining-days"></span> 일
+                        </p>
+
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover align-middle">
+                                <thead class="table-light">
+                                <tr>
+                                    <th scope="col">순번</th>
+                                    <th scope="col">제목</th>
+                                    <th scope="col">설명</th>
+                                    <th scope="col">시작</th>
+                                    <th scope="col">종료</th>
+                                    <th scope="col">사용일수</th>
+                                    <th scope="col">타입</th>
+                                </tr>
+                                </thead>
+                                <tbody id="detail-body"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    <script>
+        let membersData = [];
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const listGroup = document.getElementById('user-list');
+
+            // 1) 전체 사용자 API 호출
+            fetch('/api/v1/member/used-leaves')
+                .then(res => { if (!res.ok) throw new Error(); return res.json(); })
+                .then(users => {
+                    membersData = users;
+
+                    // 2) List Group 아이템 생성
+                    users.forEach(user => {
+                        const btn = document.createElement('button');
+                        btn.type        = 'button';
+                        btn.className   = 'btn btn-outline-primary mx-2 my-2';  // 좌우 마진 mx-2, 상하 마진 my-2
+                        btn.style.whiteSpace = 'nowrap';
+                        btn.textContent = user.memberName;
+                        btn.dataset.id  = user.memberId;
+                        btn.addEventListener('click', onUserClick);
+                        listGroup.appendChild(btn);
+                    });
+                })
+                .catch(err => console.error(err));
+        });
+
+        function onUserClick() {
+            // 1) 기존 active 제거
+            document
+                .querySelectorAll('#user-list button.active')
+                .forEach(btn => btn.classList.remove('active'));
+
+            // 2) 클릭된 버튼에만 active 추가
+            this.classList.add('active');
+
+            const memberId   = this.dataset.id;
+            const memberName = this.textContent;
+            document.getElementById('selected-user-name').textContent = memberName;
+
+            const userRecord = membersData.find(u => String(u.memberId) === memberId);
+            if (userRecord.leaveDetails) {
+                renderDetails(userRecord);
+            } else {
+                fetch(`/api/member/leave/usage?memberId=${memberId}`)
+                    .then(res => { if (!res.ok) throw new Error(); return res.json(); })
+                    .then(data => {
+                        Object.assign(userRecord, data);
+                        renderDetails(userRecord);
+                    })
+                    .catch(err => console.error(err));
+            }
+        }
+
+        function renderDetails(user) {
+            document.getElementById('total-count').textContent    = user.totalCount;
+            document.getElementById('used-days').textContent      = user.usedDays;
+            document.getElementById('remaining-days').textContent = user.remainingDays;
+
+            const tbody = document.getElementById('detail-body');
+            tbody.innerHTML = '';
+
+            user.leaveDetails.forEach((item, idx) => {
+                const tr = document.createElement('tr');
+                [
+                    idx + 1,
+                    item.title,
+                    item.description,
+                    item.start.replace('T',' '),
+                    item.end.replace('T',' '),
+                    item.usedDays,
+                    item.leaveType
+                ].forEach(text => {
+                    const td = document.createElement('td');
+                    td.textContent = text;
+                    tr.append(td);
+                });
+                tbody.append(tr);
+            });
+
+            document.getElementById('usage-detail').style.display = 'block';
+        }
+    </script>
+</div>
+</html>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -3,7 +3,7 @@
 <div layout:fragment="content">
   <div>
     <h3 class="mb-4 text-center">로그인</h3>
-    <form th:action="@{/member/login}" method="post">
+    <form th:action="@{/members/login}" method="post">
       <!-- 로그인 실패 시 파라미터로 error 전달, 스프링 시큐리티 규칙 -->
       <div th:if="${param.error}">
         <div class="alert alert-danger">


### PR DESCRIPTION
## 구현 사항 요약

- 비밀번호 변경 동작 안하던 문제 해결
- api 좀 더 restful 하도록 변경
- 연차 사용 현황 페이지 완성
- 연차 사용 현황 API 수정
  - API 2개로 분리(사용자 목록, 각 사용자별 목록 페이징)
  - Query Dsl 도입하여 쿼리 좀 더 라이트하도록 수정
- 구글 캘린더 API 호출하는 메소드 별도 Service로 분리
- 공통 예외 처리하는 CommonExceptionHandler 도입\
- JS에서 공통 예외 처리하도록 fetch 글로벌 설정 변경

## 목표 구현 사항

- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장 + **해당 일정이 얼마만큼의 연차를 소진한건지 double 컬럼 추가**
  - [x] `MEMBER` : 사용자 정보 저장
- [x] Spring Security 도입
  - [x] form_login 도입

- [x] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신
    - [x] (추가) 휴일 일정 변경, 휴일 여부 변경 등 삭제하고 다시 생성하도록 입구컷
    - [x] (추가) 일정 수정 시 수정하려는 일정이 휴일 등으로 연차 사용 시간이 0시간이라면 수정 튕겨내도록 수정
      - 사실 이미 삭제되었을 것

  - [x] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신
    - [x] (추가) 휴일 삭제할 경우 해당 기간에 속한 연차들 다시 불러와서 연차 기간 다시 계산하도록

- [x] 로그인 페이지

- [x] 연차 사용 현황 페이지

- [x] 비밀번호 변경 페이지
- [x] 비밀번호 변경 API

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [ ] API 리팩토링
  - [ ] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [x] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [x] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [x] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)
  - [ ] (추가) 파견직, 정규직 근무시간 다를 것 고려한 로직 수정(시작, 종료 시간)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현