### PR TITLE
파견직, 일반 직원 모두 사용할 수 있도록 수정 (근무 시간 다름 등 상세 조정)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,10 +92,14 @@ dependencies {
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
+    // Query Dsl
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Validator
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/CreateLeaveRequestDto.java
@@ -3,21 +3,27 @@ package com.leavebridge.calendar.dto;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import com.leavebridge.calendar.entity.LeaveAndHoliday;
 import com.leavebridge.calendar.enums.LeaveType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record CreateLeaveRequestDto(
 	@Schema(description = "일정 제목", example = "박철현 연차")
+	@NotBlank(message = "일정 제목은 필수입니다")
 	String title,
 	@Schema(description = "하루 종일 일정 여부", example = "true")
+	@NotNull(message = "하루 종일 여부는 필수입니다")
 	Boolean isAllDay,
 	@Schema(description = "연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_MORNING(오전_반차), HALF_DAY_AFTERNOON(오후 반차), OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차), NON_DEDUCTIBLE(공결, 병가, 기타 미소진 연차), MEETING(회의)")
+	@NotNull(message = "연차 종류는 필수입니다")
 	LeaveType leaveType,
 	@Schema(description = "시작 날짜", example = "2025-07-01")
+	@NotNull(message = "시작 날짜는 필수입니다")
 	LocalDate startDate,
 	@Schema(description = "종료 날짜", example = "2025-07-01")
+	@NotNull(message = "종료 날짜는 필수입니다")
 	LocalDate endDate,
 	@Schema(description = "시작 날짜 시간", example = "00:00")
 	LocalTime startTime,
@@ -29,41 +35,12 @@ public record CreateLeaveRequestDto(
 	Boolean isHolidayInclude
 ) {
 	public CreateLeaveRequestDto {
-		// 1) isAllDay == true 이면 기본적으로 하루종일(00:00~23:59:59)로 설정
-		if (Boolean.TRUE.equals(isAllDay)) {
-			// startTime, endTime 이 null 이거나 전부 공백("")로 넘어올 경우 대비
-			if (startTime == null) {
-				startTime = LocalTime.MIDNIGHT;            // 00:00:00
-			}
-			if (endTime == null) {
-				endTime   = LocalTime.of(23, 59, 59);      // 23:59:59
-			}
-
-			// 1‑a) 단, “연차 소진 타입” (isConsumesLeave==true) 은
-			//      전일 연차는 업무시간(08:00~17:00)으로 고정하도록 처리
-			if (leaveType.isConsumesLeave()) {
-				startTime = LeaveAndHoliday.WORK_START_TIME;   // 08:00
-				endTime   = LeaveAndHoliday.WORK_END_TIME;     // 17:00
-			}
+		if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+			throw new IllegalArgumentException("시작 날짜는 종료 날짜보다 이후일 수 없습니다");
 		}
 
-		// 2) !allDay 인 경우, 업무시간 범위로 전일 전환 로직
-		else {
-			// 2-1) 08:00~17:00 정확히 입력되면 전일로 간주
-			if (LeaveAndHoliday.WORK_START_TIME.equals(startTime)
-				&& LeaveAndHoliday.WORK_END_TIME.equals(endTime)) {
-				isAllDay = true;
-			}
-
-			// 2-2) 시작 ≤ 08:00 && 종료 ≥ 17:00 && 연차 소진 타입 → 전일
-			// 연차 소진 아닌 일정은 그대로 둘꺼임
-			boolean startEarlyEnough = !startTime.isAfter(LeaveAndHoliday.WORK_START_TIME);
-			boolean endLateEnough   = !endTime.isBefore(LeaveAndHoliday.WORK_END_TIME);
-			if (startEarlyEnough && endLateEnough && leaveType.isConsumesLeave()) {
-				isAllDay = true;
-				startTime = LeaveAndHoliday.WORK_START_TIME;
-				endTime   = LeaveAndHoliday.WORK_END_TIME;
-			}
+		if(startTime != null && endTime != null && !(endTime.isAfter(startTime))) {
+			throw new IllegalArgumentException("종료 시간은 시작 시간보다 늦어야합니다.");
 		}
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
+++ b/src/main/java/com/leavebridge/calendar/dto/PatchLeaveRequestDto.java
@@ -7,19 +7,26 @@ import com.leavebridge.calendar.entity.LeaveAndHoliday;
 import com.leavebridge.calendar.enums.LeaveType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record PatchLeaveRequestDto(
-	@Schema(description = "수정 일정 제목", example = "박철현 연차 수정")
+	@Schema(description = "수정 일정 제목", example = "박철현 연차")
+	@NotBlank(message = "일정 제목은 필수입니다")
 	String title,
-	@Schema(description = "수정 하루 종일 일정 여부", example = "true")
+	@Schema(description = "하루 종일 일정 여부", example = "true")
+	@NotNull(message = "하루 종일 여부는 필수입니다")
 	Boolean isAllDay,
-	@Schema(description = "수정 연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_MORNING(오전_반차), HALF_DAY_AFTERNOON(오후 반차), OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차), NON_DEDUCTIBLE(공결, 병가, 기타 미소진 연차), MEETING(회의)")
+	@Schema(description = "연차 종류", example = "HOLIDAY(공휴일), FULL_DAY_LEAVE(1일 연차), HALF_DAY_MORNING(오전_반차), HALF_DAY_AFTERNOON(오후 반차), OUT_GOING(외출), SUMMER_VACATION(여름 휴가), OTHER_PERSON(비회원 연차), NON_DEDUCTIBLE(공결, 병가, 기타 미소진 연차), MEETING(회의)")
+	@NotNull(message = "연차 종류는 필수입니다")
 	LeaveType leaveType,
-	@Schema(description = "수정 시작 날짜", example = "2025-07-01")
+	@Schema(description = "시작 날짜", example = "2025-07-01")
+	@NotNull(message = "시작 날짜는 필수입니다")
 	LocalDate startDate,
-	@Schema(description = "수정 종료 날짜", example = "2025-07-01")
+	@Schema(description = "종료 날짜", example = "2025-07-01")
+	@NotNull(message = "종료 날짜는 필수입니다")
 	LocalDate endDate,
 	@Schema(description = "수정 시작 날짜 시간", example = "00:00")
 	LocalTime startTime,
@@ -31,26 +38,12 @@ public record PatchLeaveRequestDto(
 	Boolean isHolidayInclude
 ) {
 	public PatchLeaveRequestDto {
-		if (!Boolean.TRUE.equals(isAllDay)) {
-			// 08:00~17:00 정확히이면 전일
-			if (LeaveAndHoliday.WORK_START_TIME.equals(startTime) &&
-				LeaveAndHoliday.WORK_END_TIME.equals(endTime)) {
-				isAllDay = true;
-			}
+		if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+			throw new IllegalArgumentException("시작 날짜는 종료 날짜보다 이후일 수 없습니다");
+		}
 
-			// ★ 시작 ≤ 08:00  &&  종료 ≥ 17:00  → 전일
-			boolean startEarlyEnough = !startTime.isAfter(LeaveAndHoliday.WORK_START_TIME); // ≤
-			boolean endLateEnough = !endTime.isBefore(LeaveAndHoliday.WORK_END_TIME);     // ≥
-			if (startEarlyEnough && endLateEnough) {
-				isAllDay = true;
-			}
-
-			// 타입이 전일 전용이면 강제 전일
-			if (leaveType == LeaveType.FULL_DAY_LEAVE ||
-				leaveType == LeaveType.SUMMER_VACATION ||
-				leaveType == LeaveType.PUBLIC_HOLIDAY) {
-				isAllDay = true;
-			}
+		if(startTime != null && endTime != null && !(endTime.isAfter(startTime))) {
+			throw new IllegalArgumentException("종료 시간은 시작 시간보다 늦어야합니다.");
 		}
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -44,8 +44,12 @@ import lombok.ToString;
 public class LeaveAndHoliday {
 
 	// 상수들 모아두기
-	public static final LocalTime WORK_START_TIME = LocalTime.of(8, 0);
-	public static final LocalTime WORK_END_TIME = LocalTime.of(17, 0);
+	public static final LocalTime WORK_START_TIME_FOR_GERMANY = LocalTime.of(8, 0);
+	public static final LocalTime WORK_END_TIME_FOR_GERMANY = LocalTime.of(17, 0);
+	public static final LocalTime WORK_START_TIME_FOR_MEMBER = LocalTime.of(9, 0);
+	public static final LocalTime WORK_END_TIME_FOR_MEMBER = LocalTime.of(18, 0);
+	public static final LocalTime LUNCH_BOUNDARY_TIME_FOR_GERMANY  = LocalTime.of(13, 0); // 오후연차시작
+	public static final LocalTime LUNCH_BOUNDARY_TIME_FOR_MEMBER  = LocalTime.of(14, 0);
 	public static final LocalTime LUNCH_START = LocalTime.NOON;        // 12:00
 	public static final LocalTime LUNCH_END = LocalTime.of(13, 0);   // 13:00
 
@@ -99,8 +103,8 @@ public class LeaveAndHoliday {
 	@Column(name = "IS_HOLIDAY")
 	private Boolean isHoliday;
 
-	@Column(name = "USED_LEAVE_HOURS")
-	private Double usedLeaveHours;  // 차감 연차 시간
+	@Column(name = "USED_LEAVE_DAYS")
+	private Double usedLeaveDays;  // 차감 연차 시간
 
 	@Column(name = "COMMENT")
 	private String comment;  // 연차 미차감 사유
@@ -197,7 +201,7 @@ public class LeaveAndHoliday {
 	}
 
 	public void updateUsedLeaveHours(Double usedLeaveHours) {
-		this.usedLeaveHours = usedLeaveHours;
+		this.usedLeaveDays = usedLeaveHours;
 	}
 
 	public void updateComment(String comment) {

--- a/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
+++ b/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
@@ -14,10 +14,7 @@ import com.leavebridge.calendar.enums.LeaveType;
 @Repository
 public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday, Long> {
 	List<LeaveAndHoliday> findAllByGoogleEventIdIn(List<String> eventIds);
-	List<LeaveAndHoliday> findAllByStartDateGreaterThanEqualAndStartDateLessThan(LocalDate start, LocalDate end);
 	List<LeaveAndHoliday> findAllByStartDateBetween(LocalDate yearStart, LocalDate yearEnd);
-
-	boolean existsByStartDateAndIsHolidayTrueAndIsAllDayTrue(LocalDate start);
 
 	@Query("""
 		   SELECT l FROM LeaveAndHoliday l
@@ -34,5 +31,11 @@ public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday
 
 	List<LeaveAndHoliday> findByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayFalse(
 		LocalDate endDate, LocalDate startDate);
+
+	boolean existsByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayTrueAndLeaveTypeNot(
+		LocalDate date, LocalDate date1, LeaveType leaveType);
+
+	boolean existsByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayTrue(LocalDate date, LocalDate date1);
+
 	List<LeaveAndHoliday> findAllByStartDateLessThanEqualAndEndDateGreaterThanEqual(LocalDate monthEnd, LocalDate monthStart);
 }

--- a/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
+++ b/src/main/java/com/leavebridge/calendar/repository/LeaveAndHolidayRepository.java
@@ -34,4 +34,5 @@ public interface LeaveAndHolidayRepository extends JpaRepository<LeaveAndHoliday
 
 	List<LeaveAndHoliday> findByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayFalse(
 		LocalDate endDate, LocalDate startDate);
+	List<LeaveAndHoliday> findAllByStartDateLessThanEqualAndEndDateGreaterThanEqual(LocalDate monthEnd, LocalDate monthStart);
 }

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -65,12 +65,15 @@ public class CalendarService {
 	public List<MonthlyEvent> listMonthlyEvents(int year, int month) {
 		log.info("CalendarService.listMonthlyEvents :: year={}, month={}", year, month);
 
-		LocalDate startDate = LocalDate.of(year, month, 1);
-		LocalDate endDate = startDate.plusMonths(1);  // 다음 달 1일 00:00
+		LocalDate monthStart = LocalDate.of(year, month, 1);
+		LocalDate monthEnd   = monthStart.plusMonths(1).minusDays(1);   // 해당 월의 마지막 날
 
-		// 시작일이 지정한 날짜 이상인 것
-		List<LeaveAndHoliday> currentMonthEvents = leaveAndHolidayRepository.findAllByStartDateGreaterThanEqualAndStartDateLessThan(
-			startDate, endDate);
+		/**
+		 * 일정이 월 말 이전 시작했고 일정이 월초 이후에 끝 -> 6/30 ~ 7/2 같은 일정도 7월에 포함됨
+		 * startDate <= MonthEnd && endDate >= monthStart
+		 */
+		List<LeaveAndHoliday> currentMonthEvents = leaveAndHolidayRepository
+			.findAllByStartDateLessThanEqualAndEndDateGreaterThanEqual(monthEnd, monthStart);
 
 		return currentMonthEvents.stream()
 			.map(MonthlyEvent::from)

--- a/src/main/java/com/leavebridge/calendar/service/CalendarService.java
+++ b/src/main/java/com/leavebridge/calendar/service/CalendarService.java
@@ -1,6 +1,8 @@
 package com.leavebridge.calendar.service;
 
 import static com.leavebridge.calendar.entity.LeaveAndHoliday.*;
+import static com.leavebridge.calendar.service.GoogleCalendarAPIService.*;
+import static com.leavebridge.util.TimeRuleUtils.*;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -20,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import com.google.api.client.util.Data;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
@@ -32,7 +33,7 @@ import com.leavebridge.calendar.entity.LeaveAndHoliday;
 import com.leavebridge.calendar.enums.LeaveType;
 import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
 import com.leavebridge.member.entitiy.Member;
-import com.leavebridge.util.DateUtils;
+import com.leavebridge.util.TimeRuleUtils;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -43,9 +44,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Transactional(readOnly = true)
 public class CalendarService {
-	private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
+
 	private final LeaveAndHolidayRepository leaveAndHolidayRepository;
 	private final GoogleCalendarAPIService googleCalendarAPIService;
+	private final DtoAdjustService dtoAdjustService;
+	private final GoogleEventPatcher googleEventPatcher;
 
 	/**
 	 * 특정 이벤트의 상세 정보를 조회합니다.
@@ -85,6 +88,10 @@ public class CalendarService {
 	 */
 	@Transactional
 	public void createTimedEvent(CreateLeaveRequestDto requestDto, Member member) {
+
+		// 생성 dto 입력값에 따라 맞추기
+		requestDto = dtoAdjustService.processLeaveRequestDataForCreate(requestDto, member.isGermany());
+
 		// 휴일인 경우
 		if (Boolean.TRUE.equals(requestDto.isHolidayInclude())) {
 			handleHolidayRegistration(requestDto, member);
@@ -96,7 +103,155 @@ public class CalendarService {
 	}
 
 	/**
+	 * 기존 이벤트(eventId)를 수정합니다.
+	 */
+	@Transactional
+	public void updateEventDate(Long eventId, PatchLeaveRequestDto dto, Member member) {
+		LeaveAndHoliday leaveAndHoliday = leaveAndHolidayRepository.findById(eventId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 Id를 가진 이벤트가 없습니다."));
+
+		boolean isGermany = member.isGermany();  // 파견직 여부
+
+		// 0) dto 입력값 맞추기
+		dto = dtoAdjustService.processLeaveRequestDataForUpdate(dto, isGermany);
+
+		String googleEventId = leaveAndHoliday.getGoogleEventId();
+
+		// 1) 수정 가능한지 검증 (권한, 원래 entity type 등)
+		validateToUpdateLeaveAndHolidayEntity(dto, member, leaveAndHoliday);
+
+		Event apiEvent = null;
+		boolean shouldSyncGoogle = isGermany && googleEventId != null;
+
+		// 2) (파견직 & 구글ID 존재 시) Google Calendar 이벤트 조회
+		if (shouldSyncGoogle) {
+			apiEvent = googleCalendarAPIService.getGoogleCalendarEventByGoogleEventId(googleEventId);
+		}
+
+		// 3) (파견직만) 변경사항을 API payload에 반영할지 여부 판단
+		boolean changed = false;
+		if (shouldSyncGoogle) {
+			changed = googleEventPatcher.applyAllChanges(apiEvent, dto);
+		}
+		// 4-1) 엔티티 기본 정보 수정
+		leaveAndHoliday.patchEntityByDto(dto);
+
+		// 4-2) 연차 사용량 재계산
+		if (leaveAndHoliday.getLeaveType().isConsumesLeave()) {
+			Map<String, Object> info = calcUsedDaysAndGetComment(
+				leaveAndHoliday.getStartDate(), leaveAndHoliday.getStarTime(),
+				leaveAndHoliday.getEndDate(), leaveAndHoliday.getEndTime(), isGermany
+			);
+
+			double usedDays = (double)info.get("usedDays");
+			String comment = ((String)info.get("comment"));
+
+			if (usedDays == 0.0) {
+				throw new IllegalArgumentException("해당 기간에는 휴일·주말만 포함되어 실제 차감 연차가 없습니다. " +
+												   "변경하시려면 기존 일정을 삭제한 후 다시 등록해주세요.");
+			}
+
+			leaveAndHoliday.updateUsedLeaveHours(usedDays);
+			leaveAndHoliday.updateComment(comment);
+		}
+
+		// 5) (파견직 & 변경사항 있음 & 구글ID 존재 시) Google Calendar에 수정 반영
+		if (shouldSyncGoogle && changed) {
+			googleCalendarAPIService.patchGoogleCalendarEventByEventIdAndEvent(googleEventId, apiEvent);
+		}
+	}
+
+	private void validateToUpdateLeaveAndHolidayEntity(PatchLeaveRequestDto dto, Member member,
+		LeaveAndHoliday leaveAndHoliday) {
+		checkHolidayUpdateAllowed(leaveAndHoliday, member);
+		checkOwnerOrAdmin(member, leaveAndHoliday);
+		if (dto.leaveType().isConsumesLeave()) {
+			validateLeaveForPatch(dto, member);
+		}
+
+		// 2-1) 일반 <-> 휴일 변경 불가
+		boolean wasHoliday = Boolean.TRUE.equals(leaveAndHoliday.getIsHoliday());
+		boolean nowHoliday = Boolean.TRUE.equals(dto.isHolidayInclude());
+		if (wasHoliday != nowHoliday) {
+			throw new IllegalArgumentException("일반 일정과 휴일 일정은 상호 변경할 수 없습니다. 삭제 후 재등록해주세요.");
+		}
+		// 휴일일때 일정 변경 금지
+		if (nowHoliday) {
+			// DTO 상의 startDate/startTime, endDate/endTime 이 원본과 다르면 예외
+			if (!dto.startDate().equals(leaveAndHoliday.getStartDate())
+				|| !dto.endDate().equals(leaveAndHoliday.getEndDate())
+				|| !dto.startTime().equals(leaveAndHoliday.getStarTime())
+				|| !dto.endTime().equals(leaveAndHoliday.getEndTime())
+			) {
+				throw new IllegalArgumentException("등록된 휴일 일정은 기간 변경이 불가능합니다. 삭제 후 재등록해주세요.");
+			}
+		}
+
+		//  2-2) “연차 소진" <-> "연차 미소진" 타입의 일정 변경 불가
+		boolean wasDeductible = leaveAndHoliday.getLeaveType().isConsumesLeave();
+		boolean nowDeductible = dto.leaveType().isConsumesLeave();
+		if (wasDeductible != nowDeductible) {
+			throw new IllegalArgumentException("연차 소진 타입 변경은 지원되지 않습니다. 삭제 후 재등록해 주세요.");
+		}
+	}
+
+	/**
+	 * 지정한 이벤트(eventId)를 삭제합니다.
+	 */
+	@Transactional
+	public void deleteEvent(Long eventId, Member member) {
+		LeaveAndHoliday leaveAndHoliday = leaveAndHolidayRepository.findById(eventId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 Id를 가진 이벤트가 없습니다."));
+
+		boolean isGermany = member.isGermany();  // 파견직 여부
+		String googleEventId = leaveAndHoliday.getGoogleEventId();
+
+		// 권한 및 휴일 수정 가능 여부 검증
+		checkOwnerOrAdmin(member, leaveAndHoliday);
+		checkHolidayUpdateAllowed(leaveAndHoliday, member);
+
+		// 만약 삭제 대상이 '휴일'이라면, 그 기간에 걸친 연차(consume leave)들을 미리 조회
+		boolean isDeletingHoliday = Boolean.TRUE.equals(leaveAndHoliday.getIsHoliday());
+		List<LeaveAndHoliday> impactedLeaves = Collections.emptyList();
+		if (isDeletingHoliday) {
+			// 휴일 기간 동안 연차 소모 타입에 해당하는 일정들
+			impactedLeaves = leaveAndHolidayRepository.findAllConsumesLeaveByDateRange(
+				leaveAndHoliday.getStartDate(), leaveAndHoliday.getEndDate(),
+				List.of(LeaveType.FULL_DAY_LEAVE, LeaveType.HALF_DAY_MORNING, LeaveType.HALF_DAY_AFTERNOON,
+					LeaveType.OUTING, LeaveType.SUMMER_VACATION)
+			);
+		}
+
+		// 3) DB 삭제 우선
+		leaveAndHolidayRepository.delete(leaveAndHoliday);
+		leaveAndHolidayRepository.flush();
+
+		// 3) (파견직 & googleEventId 유효할 때만) 구글 캘린더에서도 삭제
+		if (isGermany && StringUtils.hasText(googleEventId)) {
+			googleCalendarAPIService.deleteGoogleCalendarEvent(googleEventId);
+		}
+
+		// 4) 휴일 삭제 시, 영향받은 연차 재계산
+		if (isDeletingHoliday) {
+			for (LeaveAndHoliday leave : impactedLeaves) {
+				// 재계산할때 일정의 주인에 따라 달라지게(파견 or 비파견) & batch size로 N+1 해결
+				Map<String, Object> recalculated = calcUsedDaysAndGetComment(
+					leave.getStartDate(), leave.getStarTime(),
+					leave.getEndDate(), leave.getEndTime(), leave.getMember().isGermany());
+				double usedDays = (double)recalculated.get("usedDays");
+				String comment = (String)recalculated.get("comment");
+
+				// 연차 정보 업데이트
+				leave.updateUsedLeaveHours(usedDays);
+				leave.updateComment(comment);
+				leaveAndHolidayRepository.save(leave);
+			}
+		}
+	}
+
+	/**
 	 * 휴일 등록 - 등록한 휴일에 기존 일정이 있을경우 삭제 (연차 차감되는 일정들만)
+	 * -> Google Calendar 미동록
 	 */
 
 	private void handleHolidayRegistration(CreateLeaveRequestDto dto, Member member) {
@@ -104,19 +259,10 @@ public class CalendarService {
 			log.info("비관리자의 휴일 등록 시도 차단 loginId = {}", member.getLoginId());
 			throw new IllegalArgumentException("관리자만 휴일 등록이 가능합니다.");
 		}
-		// 1. 캘린더 등록
-		Event event = createCalendarEvent(dto);
-		Event created = googleCalendarAPIService.createGoogleCalendarEvent(event);
-
-		try {
-			// 2. DB 저장
-			saveEntity(dto, member, created.getId(), dto.isHolidayInclude(), 0.0, null);
-			// 3. 기존 연차 보정
-			adjustOverlappingLeaves(dto);
-		} catch (Exception e) {
-			googleCalendarAPIService.deleteGoogleCalendarEvent(created.getId());
-			throw new RuntimeException("알수없는 예외 발생", e);
-		}
+		// DB 저장
+		saveEntity(dto, member, null, dto.isHolidayInclude(), 0.0, null);
+		// 기존 연차 보정
+		adjustOverlappingLeaves(dto);
 	}
 
 	/**
@@ -126,15 +272,16 @@ public class CalendarService {
 	private void handleLeaveRegistration(CreateLeaveRequestDto requestDto, Member member) {
 		double usedDays = 0.0;
 		String comment = null;
+		boolean isGermany = member.isGermany();
 
 		// 1) “연차 소진” 타입인 경우에만 검증 & 연차 사용 처리
 		if (requestDto.leaveType().isConsumesLeave()) {
 			// 1-1. 검증(주말 혹은 휴일에 쓰려는거 아닌지)
-			validateLeave(requestDto);
+			validateLeaveForCreate(requestDto, member);
 
 			// 1-2. 연차 사용 시간 계산 (0.0 ~ N.0)
 			Map<String, Object> usedInfoMap = calcUsedDaysAndGetComment(requestDto.startDate(), requestDto.startTime(),
-				requestDto.endDate(), requestDto.endTime());
+				requestDto.endDate(), requestDto.endTime(), isGermany);
 			usedDays = (double)usedInfoMap.get("usedDays");
 			comment = (String)usedInfoMap.get("comment");
 
@@ -143,21 +290,38 @@ public class CalendarService {
 			}
 		}
 
-		// 2) Google Calendar 이벤트 생성 (소진 여부와 무관하게)
-		Event leaveEvent = createCalendarEvent(requestDto);
-		Event createdLeave = googleCalendarAPIService.createGoogleCalendarEvent(leaveEvent);
+		Event createdEvent = null;
+		// 2) 파견직만 Google Calendar 이벤트 생성
+		if (isGermany) {
+			Event ev = createCalendarEvent(requestDto);
+			createdEvent = googleCalendarAPIService.createGoogleCalendarEvent(ev);
+		}
 
-		// 3. DB 저장
+		// 3) DB 저장
 		try {
-			// 일반 사용자
-			saveEntity(requestDto, member, createdLeave.getId(), false, usedDays, comment);
-		} catch (Exception e) {
-			googleCalendarAPIService.deleteGoogleCalendarEvent(createdLeave.getId());
-			throw e;
+			saveEntity(requestDto, member, createdEvent != null ? createdEvent.getId() : null, false,
+				usedDays, comment);
+		} catch (Exception ex) {
+			if (createdEvent != null) {
+				googleCalendarAPIService.deleteGoogleCalendarEvent(createdEvent.getId());
+			}
+			throw ex;  // 다시 예외를 던져서 DB 롤백되도록
 		}
 	}
 
+	/**
+	 * 관리자 휴일 등록 시 휴일과 겹치는 일정들 조정
+	 * - 공휴일 + 국경일 + 휴가 포함 : 전체 인원 영향
+	 * - 공휴일은 보통 하루종일 이니깐 근무시간 다른것 고려 안함
+	 * - 기념일 + 휴가 포함 : 파견직 제외 직원 영향 (파견지에서의 특별 기념일 휴가는 관리자가 관리하기 어려울 것)
+	 */
 	private void adjustOverlappingLeaves(CreateLeaveRequestDto dto) {
+
+		// 0) 휴일 타입에 따른 처리 분기
+		LeaveType holidayType = dto.leaveType();
+		// 1) “기념일(ANNIVERSARY)” + 휴가 포함: 파견직 일정(googleEventId가 있는)만 건너뛰고, 일반 직원 일정만 조정
+		boolean isAnniversary = holidayType == LeaveType.ANNIVERSARY;
+
 		// 휴일 범위
 		LocalDate holStartDate = dto.startDate();
 		LocalTime holStartTime = dto.startTime();
@@ -172,6 +336,15 @@ public class CalendarService {
 		);
 
 		for (LeaveAndHoliday leave : list) {
+
+			Member owner = leave.getMember();  // batch size로 한방에 가져와서 1+N 해결함
+			boolean isGermany = owner.isGermany();
+
+			// --- 분기 1: 파견직 + 기념일 → 건너뛰기 --- (파견직은 기념일 놉)
+			if (isGermany && isAnniversary) {
+				continue;
+			}
+
 			LocalDate leaveStartDate = leave.getStartDate();
 			LocalDate leaveEndDate = leave.getEndDate();
 			LocalTime leaveStartTime = leave.getStarTime();
@@ -197,12 +370,15 @@ public class CalendarService {
 			if (fullyCovered) {
 				// 완전 포함된 연차는 삭제
 				leaveAndHolidayRepository.delete(leave);
-				googleCalendarAPIService.deleteGoogleCalendarEvent(leave.getGoogleEventId());
+				// 구글 캘린더 Id 가진 이벤트만 연동
+				if (StringUtils.hasText(leave.getGoogleEventId())) {
+					googleCalendarAPIService.deleteGoogleCalendarEvent(leave.getGoogleEventId());
+				}
 			} else {
 				// 부분 보정: 사용일수와 사유 재계산
 				Map<String, Object> info = calcUsedDaysAndGetComment(
 					leave.getStartDate(), leave.getStarTime(),
-					leave.getEndDate(), leave.getEndTime()
+					leave.getEndDate(), leave.getEndTime(), isGermany
 				);
 				double usedDays = (double)info.get("usedDays");
 				String reason = ((String)info.get("comment"));
@@ -212,15 +388,6 @@ public class CalendarService {
 				leaveAndHolidayRepository.saveAndFlush(leave);
 			}
 		}
-	}
-
-	private void validateLeave(CreateLeaveRequestDto dto) {
-		LocalDate start = dto.startDate();
-		DayOfWeek dow = start.getDayOfWeek();
-		if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY)
-			throw new IllegalArgumentException("연차는 주말을 시작일로 사용할 수 없습니다.");
-		if (isHoliday(start))
-			throw new IllegalArgumentException("연차 시작일이 휴일일 수 없습니다.");
 	}
 
 	private void saveEntity(CreateLeaveRequestDto dto, Member member, String eventId,
@@ -252,40 +419,33 @@ public class CalendarService {
 	}
 
 	// LeaveAndHoliday에서 LocalDateTime 구간 추출용 DTO
-	@Getter
-	static class DateTimeInterval {
-		private final LocalDateTime start;
-		private final LocalDateTime end;
-
-		public DateTimeInterval(LocalDateTime start, LocalDateTime end) {
-			this.start = start;
-			this.end = end;
-		}
-	}
+	record DateTimeInterval(LocalDateTime start, LocalDateTime end) { }
 
 	/**
 	 * 주어진 부분 휴일들의 겹치는 시간을 합하여 최종적으로 제외할 시간들 리스트 반환 함수
 	 */
-	private List<DateTimeInterval> mergedHolidayTimesWithLunchTime(
+	private List<DateTimeInterval> mergeHolidayIntervalsNonIncludeLunchTime(
 		List<LeaveAndHoliday> partials,
-		LocalDate targetDate
+		LocalDate targetDate, boolean isGermany
 	) {
 		List<DateTimeInterval> intervals = new ArrayList<>();
+		LocalTime adjustStartTime = getAdjustStartTime(isGermany);
+		LocalTime adjustEndTime = getAdjustEndTime(isGermany);
 
 		for (LeaveAndHoliday h : partials) {
 			// 1) 이 건이 targetDate를 포함하므로, 날짜 루프 불필요
 			// rawStart: 휴일이 targetDate 이전부터 시작됐다면 근무시작, 아니면 실제 시작시간
 			LocalTime rawStart = h.getStartDate().isBefore(targetDate)
-				? WORK_START_TIME
+				? adjustStartTime
 				: h.getStarTime();
 			// rawEnd: 휴일이 targetDate 이후까지 이어진다면 근무종료, 아니면 실제 종료시간
 			LocalTime rawEnd = h.getEndDate().isAfter(targetDate)
-				? WORK_END_TIME
+				? adjustEndTime
 				: h.getEndTime();
 
 			// 2) 근무시간 범위로 클램핑
-			LocalTime startT = rawStart.isBefore(WORK_START_TIME) ? WORK_START_TIME : rawStart;
-			LocalTime endT = rawEnd.isAfter(WORK_END_TIME) ? WORK_END_TIME : rawEnd;
+			LocalTime startT = rawStart.isBefore(adjustStartTime) ? adjustStartTime : rawStart;
+			LocalTime endT = rawEnd.isAfter(adjustEndTime) ? adjustEndTime : rawEnd;
 
 			// 3) 유효 구간이면 (시작 18시, 종료 19시면 안맞게되는 등)
 			if (startT.isBefore(endT)) {
@@ -316,7 +476,6 @@ public class CalendarService {
 				}
 			}
 		}
-
 		// 병합
 		return mergeIntervals(intervals);
 	}
@@ -330,22 +489,22 @@ public class CalendarService {
 		}
 
 		// 1) 시작 시간 기준으로 정렬 (LocalDateTime 비교)
-		intervals.sort(Comparator.comparing(DateTimeInterval::getStart));
+		intervals.sort(Comparator.comparing(DateTimeInterval::start));
 
 		List<DateTimeInterval> merged = new ArrayList<>();
 		// 2) 첫 구간으로 시작
-		DateTimeInterval current = intervals.get(0);
+		DateTimeInterval current = intervals.getFirst();
 
 		for (int i = 1; i < intervals.size(); i++) {
 			DateTimeInterval next = intervals.get(i);
 
 			// "겹치거나 연속" (current.end >= next.start)일 때 병합
-			if (!current.getEnd().isBefore(next.getStart())) {
+			if (!current.end().isBefore(next.start())) {
 				// end 시각을 둘 중 더 늦은 쪽으로 연장
-				LocalDateTime newEnd = current.getEnd().isAfter(next.getEnd())
-					? current.getEnd()
-					: next.getEnd();
-				current = new DateTimeInterval(current.getStart(), newEnd);
+				LocalDateTime newEnd = current.end().isAfter(next.end())
+					? current.end()
+					: next.end();
+				current = new DateTimeInterval(current.start(), newEnd);
 			} else {
 				// 틈이 있으면, 지금까지 병합된 current를 결과에 추가하고 next를 새로운 current로
 				merged.add(current);
@@ -362,7 +521,7 @@ public class CalendarService {
 	 * 실제 연차 사용 “일수” 계산 + 연차 비차감 사유 추출
 	 */
 	private Map<String, Object> calcUsedDaysAndGetComment(LocalDate startDate, LocalTime startTime, LocalDate endDate,
-		LocalTime endTime) {
+		LocalTime endTime, boolean isGermany) {
 
 		LocalDateTime start = LocalDateTime.of(startDate, startTime);
 		LocalDateTime end = LocalDateTime.of(endDate, endTime);
@@ -387,6 +546,11 @@ public class CalendarService {
 		 */
 		Map<LocalDate, List<LeaveAndHoliday>> partialsByDate = new HashMap<>();
 		for (LeaveAndHoliday h : allPartials) {
+			// 0) “기념일+파견직 제외”를 공통 처리
+			//    - dto가 ANNIVERSARY인데 등록하려는 회원이 파견직이면 아무 것도 하지 않음(차감 안함)
+			if (h.getLeaveType() == LeaveType.ANNIVERSARY && isGermany) {
+				continue;
+			}
 			LocalDate from = h.getStartDate();
 			LocalDate to = h.getEndDate();
 			for (LocalDate d = from; !d.isAfter(to); d = d.plusDays(1)) {
@@ -409,9 +573,9 @@ public class CalendarService {
 				continue;
 			}
 
-			// 2) 전일 휴일 스킵
-			if (isHoliday(d)) {
-				reasonBuilder.append("[").append(d).append("] 전일 휴일이 포함된 일정 제외\n");
+			// 2) 전일 휴일이 포함된 일정이면 스킵
+			if (isHoliday(d, isGermany)) {
+				reasonBuilder.append("[").append(d).append("] 하루종일 휴일이 포함된 일정 제외\n");
 				continue;
 			}
 
@@ -422,33 +586,33 @@ public class CalendarService {
 			// 시작, 종료일이 아니라면 중간에 낀거니까 이건 1일 연차임이 자명 -> 일 시작, 종료 시간으로 세팅
 			LocalDateTime dayStart = d.equals(start.toLocalDate())
 				? start // 이번 반복이 시작일과 같다면 이 날짜의 연차 시작으로 봄
-				: d.atTime(WORK_START_TIME); // 이번 반복이 시작일이 아니라면 이 날짜의 08시로 시작
+				: d.atTime(getAdjustStartTime(isGermany)); // 이번 반복이 시작일이 아니라면 이 날짜의 근무시간 시작
 
 			LocalDateTime dayEnd = d.equals(end.toLocalDate())
 				? end // 이번 반복의 종료일이 매개변수 종료일과 같다면 이 날짜의 연차 끝날로봄
-				: d.atTime(WORK_END_TIME); // 이번 반복이 연차 종료일이 아니라면(중간일 - 당연히 1일 연차니깐 일과 끝나는 시간으로 변경)
+				: d.atTime(getAdjustEndTime(isGermany)); // 이번 반복이 연차 종료일이 아니라면(중간일 - 당연히 1일 연차니깐 일과 끝나는 시간으로 변경)
 
 			// 5) 점심시간에만 있는 일정 스킵
 			if (isOnlyLunch(dayStart, dayEnd)) {
 				reasonBuilder
-					.append("[").append(d).append("] 점심시간(12:00~13:00) 전부 제외\n");
+					.append("[").append(d).append("] 점심시간(12:00~13:00) 만 포함된 일정 전부 제외\n");
 				continue;
 			}
 
-			// 6) 해당 일자에 이미 존재하는 휴일들의 시간 중복을 합친 새로운 일정 반환(d 날짜의 점심시간도 항상 포함)
-			List<DateTimeInterval> intervals = mergedHolidayTimesWithLunchTime(partials, d);
+			// 6) 해당 일자에 이미 존재하는 휴일들의 시간 중복을 합친 새로운 일정 반환(점심시간 포함이면 전후로)
+			List<DateTimeInterval> intervals = mergeHolidayIntervalsNonIncludeLunchTime(partials, d, isGermany);
 
 			// 7) 기본 분 계산 - 점심시간 포함하면 1시간 제외
 			long minutes = Duration.between(dayStart, dayEnd).toMinutes();
-			if (isLunchIncluded(dayStart.toLocalTime(), dayEnd.toLocalTime())) {
+			if (TimeRuleUtils.isLunchIncluded(dayStart.toLocalTime(), dayEnd.toLocalTime())) {
 				minutes -= 60;
 			}
 			long overlapMin = 0;
 
 			// 8) 부분 휴일과 겹치는 분 차감
 			for (DateTimeInterval interval : intervals) {
-				LocalDateTime holStart = interval.getStart();
-				LocalDateTime holEnd = interval.getEnd();
+				LocalDateTime holStart = interval.start();
+				LocalDateTime holEnd = interval.end();
 
 				// 계산을 위해 요청 구간과 휴일 구간 겹치는 부분(시작점, 종료점) 추출
 				LocalDateTime overlapStart = dayStart.isAfter(holStart) ? dayStart : holStart;
@@ -481,149 +645,20 @@ public class CalendarService {
 	}
 
 	/**
-	 * 12:00~13:00 구간이 포함되는지
+	 * 주어진 날이 시작일인 휴일인 일정이 한개라도 있는지 반환
+	 * 단 파견직의 경우 관리자가 등록한 "기념일 +휴일"은 휴일로 취급하지 않는다.
 	 */
-	private boolean isLunchIncluded(LocalTime st, LocalTime en) {
-		return !st.isAfter(LUNCH_START)   //  st ≤ 12:00
-			   && !en.isBefore(LUNCH_END);   //  en ≥ 13:00
-	}
-
-	/**
-	 * 12:00 ~ 13:00 구간 전부만 포함한 일정인지 여부
-	 */
-	private boolean isOnlyLunch(LocalDateTime start, LocalDateTime end) {
-		return !start.toLocalTime().isBefore(LUNCH_START)   // start ≥ 12:00
-			   && !end.toLocalTime().isAfter(LUNCH_END);       // end   ≤ 13:00
-	}
-
-	private boolean isHoliday(LocalDate startDate) {
-		// 하루종일 쉬는 날인지 반환 (기념일 & 휴일) -> 시작일만 안맞으면 사실 괜찮으니
-		return leaveAndHolidayRepository.existsByStartDateAndIsHolidayTrueAndIsAllDayTrue(startDate);
-	}
-
-	/**
-	 * 기존 이벤트(eventId)를 수정합니다.
-	 */
-	@Transactional
-	public void updateEventDate(Long eventId, PatchLeaveRequestDto dto, Member member) {
-		LeaveAndHoliday leaveAndHoliday = leaveAndHolidayRepository.findById(eventId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 Id를 가진 이벤트가 없습니다."));
-
-		// 1) 수정 가능한 타입인지, 관리자 또는 일정 등록자인지, 연차 시작이 휴일 시작 또는 주말 인지 검증
-		checkHolidayUpdateAllowed(leaveAndHoliday, member);
-		checkOwnerOrAdmin(member, leaveAndHoliday);
-		if (dto.leaveType().isConsumesLeave()) {
-			validateLeaveForPatch(dto);
-		}
-
-		// 2-1) 일반 <-> 휴일 변경 불가
-		boolean wasHoliday = Boolean.TRUE.equals(leaveAndHoliday.getIsHoliday());
-		boolean nowHoliday = Boolean.TRUE.equals(dto.isHolidayInclude());
-		if (wasHoliday != nowHoliday) {
-			throw new IllegalArgumentException("일반 일정과 휴일 일정은 상호 변경할 수 없습니다. 삭제 후 재등록해주세요.");
-		}
-		// 휴일일때 일정 변경 금지
-		if(nowHoliday) {
-			// DTO 상의 startDate/startTime, endDate/endTime 이 원본과 다르면 예외
-			if (!dto.startDate().equals(leaveAndHoliday.getStartDate())
-				|| !dto.endDate().equals(leaveAndHoliday.getEndDate())
-				|| !dto.startTime().equals(leaveAndHoliday.getStarTime())
-				|| !dto.endTime().equals(leaveAndHoliday.getEndTime())
-			) {
-				throw new IllegalArgumentException("등록된 휴일 일정은 기간 변경이 불가능합니다. 삭제 후 재등록해주세요.");
-			}
-		}
-
-		//  2-2) “연차 소진" <-> "연차 미소진" 타입의 일정 변경 불가
-		boolean wasDeductible = leaveAndHoliday.getLeaveType().isConsumesLeave();
-		boolean nowDeductible = dto.leaveType().isConsumesLeave();
-		if (wasDeductible != nowDeductible) {
-			throw new IllegalArgumentException("연차 소진 타입 변경은 지원되지 않습니다. 삭제 후 재등록해 주세요.");
-		}
-
-		// 3) Google Calendar에 등록된 이벤트 정보 조회
-		String googleEventId = leaveAndHoliday.getGoogleEventId();
-		Event apiEvent = googleCalendarAPIService.getGoogleCalendarEventByGoogleEventId(googleEventId);
-
-		// 4)  applyAllChanges 에서 API payload에 반영해야 할 변경이 있었는지 저장
-		boolean changed = applyAllChanges(apiEvent, dto);
-
-		// 5-1) 엔티티 기본 정보 수정
-		leaveAndHoliday.patchEntityByDto(dto);
-
-		// 5-2) 연차 사용량 재계산
-		if (leaveAndHoliday.getLeaveType().isConsumesLeave()) {
-			Map<String, Object> info = calcUsedDaysAndGetComment(
-				leaveAndHoliday.getStartDate(), leaveAndHoliday.getStarTime(),
-				leaveAndHoliday.getEndDate(), leaveAndHoliday.getEndTime()
-			);
-
-			double usedDays = (double)info.get("usedDays");
-			String comment = ((String)info.get("comment"));
-
-			if (usedDays == 0.0) {
-				throw new IllegalArgumentException("해당 기간에는 휴일·주말만 포함되어 실제 차감 연차가 없습니다. " +
-												   "변경하시려면 기존 일정을 삭제한 후 다시 등록해주세요.");
-			}
-
-			leaveAndHoliday.updateUsedLeaveHours(usedDays);
-			leaveAndHoliday.updateComment(comment);
-		}
-
-		// 6) PATCH 호출하여 구글 캘린더에도 수정 반영하기
-		if (changed) {
-			googleCalendarAPIService.patchGoogleCalendarEventByEventIdAndEvent(googleEventId, apiEvent);
-		}
-	}
-
-	/**
-	 * 지정한 이벤트(eventId)를 삭제합니다.
-	 */
-	@Transactional
-	public void deleteEvent(Long eventId, Member member) {
-		LeaveAndHoliday leaveAndHoliday = leaveAndHolidayRepository.findById(eventId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 Id를 가진 이벤트가 없습니다."));
-
-		checkOwnerOrAdmin(member, leaveAndHoliday);
-		checkHolidayUpdateAllowed(leaveAndHoliday, member);
-
-		// 만약 삭제 대상이 '휴일'이라면, 그 기간에 걸친 연차(consume leave)들을 미리 조회
-		boolean isDeletingHoliday = Boolean.TRUE.equals(leaveAndHoliday.getIsHoliday());
-		List<LeaveAndHoliday> impactedLeaves = Collections.emptyList();
-		if (isDeletingHoliday) {
-			// 휴일 기간 동안 연차 소모 타입에 해당하는 일정들
-			impactedLeaves = leaveAndHolidayRepository.findAllConsumesLeaveByDateRange(
-				leaveAndHoliday.getStartDate(), leaveAndHoliday.getEndDate(),
-				List.of(LeaveType.FULL_DAY_LEAVE, LeaveType.HALF_DAY_MORNING, LeaveType.HALF_DAY_AFTERNOON,
-					LeaveType.OUTING, LeaveType.SUMMER_VACATION)
-			);
-		}
-
-		// 3) DB 삭제 우선
-		leaveAndHolidayRepository.delete(leaveAndHoliday);
-		leaveAndHolidayRepository.flush();
-
-		// 4) 구글 캘린더에서도 삭제
-		if (StringUtils.hasText(leaveAndHoliday.getGoogleEventId())) {
-			googleCalendarAPIService.deleteGoogleCalendarEvent(leaveAndHoliday.getGoogleEventId());
-		}
-
-		// 5) 만약 삭제 대상이 휴일이었다면, 영향을 받은 연차들을 재계산
-		if (isDeletingHoliday) {
-			for (LeaveAndHoliday leave : impactedLeaves) {
-				// calcUsedDaysAndGetComment 메서드로 새 연차 사용량과 코멘트 얻기
-				Map<String, Object> recalculated = calcUsedDaysAndGetComment(
-					leave.getStartDate(), leave.getStarTime(),
-					leave.getEndDate(), leave.getEndTime()
-				);
-				double usedDays = (double)recalculated.get("usedDays");
-				String comment = (String)recalculated.get("comment");
-
-				// 연차 정보 업데이트
-				leave.updateUsedLeaveHours(usedDays);
-				leave.updateComment(comment);
-				leaveAndHolidayRepository.save(leave);
-			}
+	private boolean isHoliday(LocalDate date, boolean isGermany) {
+		if (isGermany) {
+			// date 가 휴일 기간 내에 속하고, ANNIVERSARY(기념일)가 아닌 하루종일 휴일이 있는지
+			return leaveAndHolidayRepository
+				.existsByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayTrueAndLeaveTypeNot(
+					date, date, LeaveType.ANNIVERSARY);
+		} else {
+			// date 가 휴일 기간 내에 속하는 모든 하루종일 휴일을 고려
+			return leaveAndHolidayRepository
+				.existsByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayTrue(
+					date, date);
 		}
 	}
 
@@ -657,138 +692,6 @@ public class CalendarService {
 		}
 	}
 
-	/**
-	 * apiEvent에 dto의 변경값을 적용하고, 하나라도 바뀌면 true 반환
-	 */
-	private boolean applyAllChanges(Event apiEvent, PatchLeaveRequestDto dto) {
-		boolean changed = false;
-		// |= 복합대입 연산자 사용해서 true가 한번이라도 나오면 무조건 true로 반환하도록
-		// |= 연산자는 불리언에서 비단락 평가 논리합 연산 - 단락 평가(short-circuit) 하지 않아 오른쪽도 항상 검사
-		// -> 즉 제목 변경이 이미 되었지만, 설명이나 일정도 변경되었을 수 있기에 메소드 무조건 실행하긴 함
-
-		// 1) summary(제목) 검사/적용
-		changed |= updateSummaryIfChanged(apiEvent, dto);
-
-		// 2) description(설명) 검사/적용
-		changed |= updateDescriptionIfChanged(apiEvent, dto);
-
-		// 3) start/end DateTime 업데이트
-		changed |= updateDateTimeIfChanged(apiEvent, dto);
-
-		return changed;
-	}
-
-	/**
-	 * 제목 업데이트
-	 */
-	private boolean updateSummaryIfChanged(Event apiEvent, PatchLeaveRequestDto dto) {
-		if (StringUtils.hasText(dto.title()) && !dto.title().equals(apiEvent.getSummary())) {
-			apiEvent.setSummary(dto.title());
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	 * 설명 업데이트
-	 */
-	private boolean updateDescriptionIfChanged(Event apiEvent, PatchLeaveRequestDto dto) {
-		if (StringUtils.hasText(dto.description()) && !dto.description().equals(apiEvent.getDescription())) {
-			apiEvent.setDescription(dto.description());
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	 * 현재 apiEvent 에 dto 로 받은 날짜/시간을 반영한다.
-	 * 변경이 있었으면 true, 없으면 false
-	 */
-	private boolean updateDateTimeIfChanged(Event apiEvent, PatchLeaveRequestDto dto) {
-
-		ZoneId zone = ZoneId.of(DEFAULT_TIME_ZONE);
-
-		// ---------- 1) DTO → 목표 값 계산 ----------
-		boolean wantedAllDay = Boolean.TRUE.equals(dto.isAllDay());
-
-		LocalDateTime wantedStart = wantedAllDay
-			? dto.startDate().atStartOfDay()
-			: LocalDateTime.of(dto.startDate(), dto.startTime());
-
-		LocalDateTime wantedEnd = wantedAllDay
-			? dto.endDate().plusDays(1).atStartOfDay()       // ★ 전일은 +1day 00:00
-			: LocalDateTime.of(dto.endDate(), dto.endTime());
-
-		// ---------- 2) 현재 값 가져오기 ----------
-		boolean currentAllDay = apiEvent.getStart().getDate() != null;
-
-		LocalDateTime currentStart;
-		LocalDateTime currentEnd;
-
-		if (currentAllDay) {
-    /* 전일 일정 ─ start·end 에는 '날짜만' 들어 있으므로
-       → LocalDate 로 파싱한 뒤 자정으로 맞춰 LocalDateTime 생성 */
-			currentStart = LocalDate
-				.parse(apiEvent.getStart().getDate().toString())   // "2025-07-28"
-				.atStartOfDay();                                   // 2025-07-28T00:00
-			currentEnd = LocalDate
-				.parse(apiEvent.getEnd().getDate().toString())     // 구글은 다음날 00:00 저장
-				.atStartOfDay();                                   // 2025-07-29T00:00
-		} else {
-			/* 시간 지정 일정 ─ millisecond epoch 값 → LocalDateTime */
-			currentStart = DateUtils.convertToLocalDateTime(apiEvent.getStart().getDateTime().getValue());
-			currentEnd = DateUtils.convertToLocalDateTime(apiEvent.getEnd().getDateTime().getValue());
-		}
-
-		// ---------- 3) 변동 여부 확인 ----------
-		// 하루종일 일정 == 바꿀일정도 하루종일 일정 & 일자도 같다 -> 변동 없음
-		if (wantedAllDay == currentAllDay && wantedStart.equals(currentStart) && wantedEnd.equals(currentEnd)) {
-			return false;
-		}
-
-		// ---------- 4) EventDateTime 새로 만들어 교체 ----------
-		// 하루종일 일정으로 변경하고싶다 -> 새로운날의 하루종일 일정으로 변경
-		if (wantedAllDay) {
-
-			// 전일(all-day)로 바꿔야 할 경우 - 기존꺼에 업데이트 하기 때문에 Null 확실하게 처리해야 함
-			EventDateTime newStart = new EventDateTime()
-				.setDateTime(Data.NULL_DATE_TIME)   // 👈 반드시 포함
-				.setTimeZone(null)
-				.setDate(
-					new DateTime(wantedStart.toLocalDate().toString())
-				);
-
-			EventDateTime newEnd = new EventDateTime()
-				.setDateTime(Data.NULL_DATE_TIME)
-				.setTimeZone(null)
-				.setDate(
-					new DateTime(wantedEnd.toLocalDate().toString())
-				);
-
-			apiEvent.setStart(newStart);
-			apiEvent.setEnd(newEnd);
-		}
-		// 바꿀 일정이 하루종일이 아닌거로 바뀔경우 -> 새로운거로 변경
-		else {
-			DateTime startDt = new DateTime(
-				Date.from(wantedStart.atZone(zone).toInstant())); // 2025-07-28T13:00:00+09:00
-			DateTime endDt = new DateTime(
-				Date.from(wantedEnd.atZone(zone).toInstant()));   // 2025-07-28T17:00:00+09:00
-
-			apiEvent.setStart(new EventDateTime()
-				.setDate(Data.NULL_DATE_TIME)            // date 필드 제거(시간 지정 이벤트이므로)
-				.setDateTime(startDt)
-				.setTimeZone(zone.getId()));
-
-			apiEvent.setEnd(new EventDateTime()
-				.setDate(Data.NULL_DATE_TIME)
-				.setDateTime(endDt)
-				.setTimeZone(zone.getId()));
-		}
-
-		return true;
-	}
-
 	private boolean checkOwnerOrAdminMember(Member member, LeaveAndHoliday leaveAndHoliday) {
 		// 로그인 안했으면 그냥 나가리
 		if (member == null) {
@@ -799,12 +702,28 @@ public class CalendarService {
 		return isOwer || isAdmin;
 	}
 
-	private void validateLeaveForPatch(PatchLeaveRequestDto dto) {
+	/**
+	 * 파견직 - 기념일 휴일에 연차 사용할 수 있도록
+	 */
+	private void validateLeaveForCreate(CreateLeaveRequestDto dto, Member member) {
 		LocalDate start = dto.startDate();
 		DayOfWeek dow = start.getDayOfWeek();
-		if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY)
-			throw new IllegalArgumentException("연차는 주말을 시작일로 사용할 수 없습니다.");
-		if (isHoliday(start))
-			throw new IllegalArgumentException("연차 시작일이 휴일일 수 없습니다.");
+		if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) {
+			throw new IllegalArgumentException("연차 시작일로 주말을 선택할 수 없습니다.");
+		}
+		if (isHoliday(start, member.isGermany())) {
+			throw new IllegalArgumentException("연차 시작일로 휴일을 선택할 수 없습니다.");
+		}
+	}
+
+	private void validateLeaveForPatch(PatchLeaveRequestDto dto, Member member) {
+		LocalDate start = dto.startDate();
+		DayOfWeek dow = start.getDayOfWeek();
+		if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) {
+			throw new IllegalArgumentException("연차 시작일로 주말을 선택할 수 없습니다.");
+		}
+		if (isHoliday(start, member.isGermany())) {
+			throw new IllegalArgumentException("연차 시작일로 휴일을 선택할 수 없습니다.");
+		}
 	}
 }

--- a/src/main/java/com/leavebridge/calendar/service/DtoAdjustService.java
+++ b/src/main/java/com/leavebridge/calendar/service/DtoAdjustService.java
@@ -1,0 +1,103 @@
+package com.leavebridge.calendar.service;
+
+import static com.leavebridge.util.TimeRuleUtils.*;
+
+import java.time.LocalTime;
+
+import org.springframework.stereotype.Service;
+
+import com.leavebridge.calendar.dto.CreateLeaveRequestDto;
+import com.leavebridge.calendar.dto.PatchLeaveRequestDto;
+import com.leavebridge.calendar.enums.LeaveType;
+
+@Service
+public class DtoAdjustService {
+
+	/**
+	 * Dto 값 조정을 위한 내부 Record 및 함수
+	 * Leave Type에 따라서 시작, 종료 시간 및 allDay 여부를 수정한다.
+	 * 단 공휴일, 기념일의 경우 휴일 포함 여부 값이 오지 않으면 예외를 던진다.
+	 */
+	private record Adjusted(LocalTime start, LocalTime end, boolean allDay) { }
+
+
+	/**
+	 * 생성 Dto 조절
+	 */
+	public CreateLeaveRequestDto processLeaveRequestDataForCreate(CreateLeaveRequestDto requestDto,
+		boolean isGermany) {
+		// 1. Dto 값 조정
+		Adjusted adjustedDto = adjustByLeaveType(requestDto.leaveType(), isGermany, requestDto.startTime(),
+			requestDto.endTime(), requestDto.isAllDay(), requestDto.isHolidayInclude());
+
+		// 2) 새로운 CreateLeaveRequestDto 반환
+		return new CreateLeaveRequestDto(
+			requestDto.title(), adjustedDto.allDay(), requestDto.leaveType(),
+			requestDto.startDate(), requestDto.endDate(),
+			adjustedDto.start(), adjustedDto.end(),
+			requestDto.description(), requestDto.isHolidayInclude()
+		);
+	}
+
+	/**
+	 * 수정 Dto 조절
+	 */
+	public PatchLeaveRequestDto processLeaveRequestDataForUpdate(PatchLeaveRequestDto requestDto, boolean isGermany) {
+		// 1. Dto 값 조정
+		Adjusted adjustedDto = adjustByLeaveType(requestDto.leaveType(), isGermany, requestDto.startTime(),
+			requestDto.endTime(), requestDto.isAllDay(),
+			requestDto.isHolidayInclude());
+
+		// 2_ 새로운 PatchLeaveRequestDto 반환
+		return new PatchLeaveRequestDto(requestDto.title(), adjustedDto.allDay(), requestDto.leaveType(),
+			requestDto.startDate(),
+			requestDto.endDate(), adjustedDto.start(), adjustedDto.end(), requestDto.description(),
+			requestDto.isHolidayInclude()
+		);
+	}
+
+	/**
+	 * LeaveType에 따른 로직, 내부에서만 접근 가능
+	 */
+	private Adjusted adjustByLeaveType(LeaveType type, boolean isGermany, LocalTime start, LocalTime end,
+		Boolean allDay, Boolean isHolidayInclude) {
+
+		LocalTime workStart = getAdjustStartTime(isGermany);
+		LocalTime halfBoundary = getAdjustLunchBoundaryTime(isGermany);
+		LocalTime workEnd = getAdjustEndTime(isGermany);
+
+		switch (type) {
+			case FULL_DAY_LEAVE, SUMMER_VACATION -> {
+				start = workStart;
+				end = workEnd;
+				allDay = true;
+			}
+			case HALF_DAY_MORNING -> {
+				start = workStart;
+				end = halfBoundary;
+				allDay = false;
+			}
+			case HALF_DAY_AFTERNOON -> {
+				start = halfBoundary;
+				end = workEnd;
+				allDay = false;
+			}
+			case OUTING -> {
+				if (start == null || end == null)
+					throw new IllegalArgumentException("외출 시간 미입력 시 등록 불가");
+				if (!start.isAfter(workStart))
+					start = workStart;   // start ≤ workStart
+				if (!end.isBefore(workEnd))
+					end = workEnd;     // end   ≥ workEnd
+				allDay = start.equals(workStart) && end.equals(workEnd);
+			}
+			case PUBLIC_HOLIDAY, ANNIVERSARY -> {
+				if (isHolidayInclude == null)
+					throw new IllegalArgumentException("공휴일, 기념일 입력 시 휴일 포함 여부는 필수입니다");
+			}
+		}
+		return new Adjusted(start, end, allDay);
+	}
+
+
+}

--- a/src/main/java/com/leavebridge/calendar/service/GoogleCalendarAPIService.java
+++ b/src/main/java/com/leavebridge/calendar/service/GoogleCalendarAPIService.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class GoogleCalendarAPIService {
+	public static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
 	private final Calendar calendarClient;
 
 	@Value("${google.calendar-id}")

--- a/src/main/java/com/leavebridge/calendar/service/GoogleEventPatcher.java
+++ b/src/main/java/com/leavebridge/calendar/service/GoogleEventPatcher.java
@@ -1,0 +1,154 @@
+package com.leavebridge.calendar.service;
+
+import static com.leavebridge.calendar.service.GoogleCalendarAPIService.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.google.api.client.util.Data;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.EventDateTime;
+import com.leavebridge.calendar.dto.PatchLeaveRequestDto;
+import com.leavebridge.util.DateUtils;
+
+@Service
+public class GoogleEventPatcher {
+
+	/**
+	 * apiEvent에 dto의 변경값을 적용하고, 하나라도 바뀌면 true 반환
+	 */
+	public boolean applyAllChanges(Event apiEvent, PatchLeaveRequestDto dto) {
+		boolean changed = false;
+		// |= 복합대입 연산자 사용해서 true가 한번이라도 나오면 무조건 true로 반환하도록
+		// |= 연산자는 불리언에서 비단락 평가 논리합 연산 - 단락 평가(short-circuit) 하지 않아 오른쪽도 항상 검사
+		// -> 즉 제목 변경이 이미 되었지만, 설명이나 일정도 변경되었을 수 있기에 메소드 무조건 실행하긴 함
+
+		// 1) summary(제목) 검사/적용
+		changed |= updateSummaryIfChanged(apiEvent, dto);
+
+		// 2) description(설명) 검사/적용
+		changed |= updateDescriptionIfChanged(apiEvent, dto);
+
+		// 3) start/end DateTime 업데이트
+		changed |= updateDateTimeIfChanged(apiEvent, dto);
+
+		return changed;
+	}
+
+	/**
+	 * 제목 업데이트
+	 */
+	private boolean updateSummaryIfChanged(Event apiEvent, PatchLeaveRequestDto dto) {
+		if (StringUtils.hasText(dto.title()) && !dto.title().equals(apiEvent.getSummary())) {
+			apiEvent.setSummary(dto.title());
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * 설명 업데이트
+	 */
+	private boolean updateDescriptionIfChanged(Event apiEvent, PatchLeaveRequestDto dto) {
+		if (StringUtils.hasText(dto.description()) && !dto.description().equals(apiEvent.getDescription())) {
+			apiEvent.setDescription(dto.description());
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * 현재 apiEvent 에 dto 로 받은 날짜/시간을 반영한다.
+	 * 변경이 있었으면 true, 없으면 false
+	 */
+	private boolean updateDateTimeIfChanged(Event apiEvent, PatchLeaveRequestDto dto) {
+
+		ZoneId zone = ZoneId.of(DEFAULT_TIME_ZONE);
+
+		// ---------- 1) DTO → 목표 값 계산 ----------
+		boolean wantedAllDay = Boolean.TRUE.equals(dto.isAllDay());
+
+		LocalDateTime wantedStart = wantedAllDay
+			? dto.startDate().atStartOfDay()
+			: LocalDateTime.of(dto.startDate(), dto.startTime());
+
+		LocalDateTime wantedEnd = wantedAllDay
+			? dto.endDate().plusDays(1).atStartOfDay()       // ★ 전일은 +1day 00:00
+			: LocalDateTime.of(dto.endDate(), dto.endTime());
+
+		// ---------- 2) 현재 값 가져오기 ----------
+		boolean currentAllDay = apiEvent.getStart().getDate() != null;
+
+		LocalDateTime currentStart;
+		LocalDateTime currentEnd;
+
+		if (currentAllDay) {
+    /* 전일 일정 ─ start·end 에는 '날짜만' 들어 있으므로
+       → LocalDate 로 파싱한 뒤 자정으로 맞춰 LocalDateTime 생성 */
+			currentStart = LocalDate
+				.parse(apiEvent.getStart().getDate().toString())   // "2025-07-28"
+				.atStartOfDay();                                   // 2025-07-28T00:00
+			currentEnd = LocalDate
+				.parse(apiEvent.getEnd().getDate().toString())     // 구글은 다음날 00:00 저장
+				.atStartOfDay();                                   // 2025-07-29T00:00
+		} else {
+			/* 시간 지정 일정 ─ millisecond epoch 값 → LocalDateTime */
+			currentStart = DateUtils.convertToLocalDateTime(apiEvent.getStart().getDateTime().getValue());
+			currentEnd = DateUtils.convertToLocalDateTime(apiEvent.getEnd().getDateTime().getValue());
+		}
+
+		// ---------- 3) 변동 여부 확인 ----------
+		// 하루종일 일정 == 바꿀일정도 하루종일 일정 & 일자도 같다 -> 변동 없음
+		if (wantedAllDay == currentAllDay && wantedStart.equals(currentStart) && wantedEnd.equals(currentEnd)) {
+			return false;
+		}
+
+		// ---------- 4) EventDateTime 새로 만들어 교체 ----------
+		// 하루종일 일정으로 변경하고싶다 -> 새로운날의 하루종일 일정으로 변경
+		if (wantedAllDay) {
+
+			// 전일(all-day)로 바꿔야 할 경우 - 기존꺼에 업데이트 하기 때문에 Null 확실하게 처리해야 함
+			EventDateTime newStart = new EventDateTime()
+				.setDateTime(Data.NULL_DATE_TIME)   // 👈 반드시 포함
+				.setTimeZone(null)
+				.setDate(
+					new DateTime(wantedStart.toLocalDate().toString())
+				);
+
+			EventDateTime newEnd = new EventDateTime()
+				.setDateTime(Data.NULL_DATE_TIME)
+				.setTimeZone(null)
+				.setDate(
+					new DateTime(wantedEnd.toLocalDate().toString())
+				);
+
+			apiEvent.setStart(newStart);
+			apiEvent.setEnd(newEnd);
+		}
+		// 바꿀 일정이 하루종일이 아닌거로 바뀔경우 -> 새로운거로 변경
+		else {
+			DateTime startDt = new DateTime(
+				Date.from(wantedStart.atZone(zone).toInstant())); // 2025-07-28T13:00:00+09:00
+			DateTime endDt = new DateTime(
+				Date.from(wantedEnd.atZone(zone).toInstant()));   // 2025-07-28T17:00:00+09:00
+
+			apiEvent.setStart(new EventDateTime()
+				.setDate(Data.NULL_DATE_TIME)            // date 필드 제거(시간 지정 이벤트이므로)
+				.setDateTime(startDt)
+				.setTimeZone(zone.getId()));
+
+			apiEvent.setEnd(new EventDateTime()
+				.setDate(Data.NULL_DATE_TIME)
+				.setDateTime(endDt)
+				.setTimeZone(zone.getId()));
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/com/leavebridge/home/HomeController.java
+++ b/src/main/java/com/leavebridge/home/HomeController.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import com.leavebridge.member.entitiy.MemberRole;
+
 @Controller
 public class HomeController {
 
@@ -14,6 +16,12 @@ public class HomeController {
 		boolean isAuthenticated = authentication != null && authentication.isAuthenticated()
 								  && !(authentication instanceof AnonymousAuthenticationToken);
 		model.addAttribute("isAuthenticated", isAuthenticated);
+
+		boolean isGermany = false;
+		if(isAuthenticated)
+			isGermany = authentication.getAuthorities().contains(MemberRole.ROLE_GERMANY);
+
+		model.addAttribute("isGermany", isGermany);
 		return "calendar/home";
 	}
 }

--- a/src/main/java/com/leavebridge/member/converter/MemberRoleListConverter.java
+++ b/src/main/java/com/leavebridge/member/converter/MemberRoleListConverter.java
@@ -1,0 +1,40 @@
+package com.leavebridge.member.converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.leavebridge.member.entitiy.MemberRole;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class MemberRoleListConverter implements AttributeConverter<List<MemberRole>, String> {
+
+	private static final String SPLIT_CHAR = ", ";
+
+	// DB 저장 시: List<MemberRole> -> "ROLE_MEMBER, ROLE_ADMIN"
+	@Override
+	public String convertToDatabaseColumn(List<MemberRole> attribute) {
+		if (attribute == null || attribute.isEmpty()) {
+			return "";
+		}
+		return attribute.stream()
+			.map(MemberRole::name)
+			.collect(Collectors.joining(SPLIT_CHAR));
+	}
+
+	// 조회 시: "ROLE_MEMBER, ROLE_ADMIN" -> List<MemberRole>
+	@Override
+	public List<MemberRole> convertToEntityAttribute(String dbData) {
+		if (dbData == null || dbData.isBlank()) {
+			return Collections.emptyList();
+		}
+		return Arrays.stream(dbData.split(SPLIT_CHAR))
+			.map(String::trim)
+			.map(MemberRole::valueOf)
+			.toList();
+	}
+}

--- a/src/main/java/com/leavebridge/member/entitiy/Member.java
+++ b/src/main/java/com/leavebridge/member/entitiy/Member.java
@@ -9,11 +9,11 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.security.core.GrantedAuthority;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
+import com.leavebridge.member.converter.MemberRoleListConverter;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -54,9 +54,11 @@ public class Member {
 	@Builder.Default
 	private List<LeaveAndHoliday> leaveAndHolidays = new ArrayList<>();
 
+	// 콤마 구분 문자열 ↔ List<MemberRole> 변환기 지정
+	@Convert(converter = MemberRoleListConverter.class)
 	@Column(name = "MEMBER_ROLE")
-	@Enumerated(EnumType.STRING)
-	private MemberRole memberRole;
+	@Builder.Default
+	private List<MemberRole> memberRoleList = new ArrayList<>();
 
 	@Column(name = "CREATED_DATE")
 	@CreatedDate
@@ -67,7 +69,7 @@ public class Member {
 	private LocalDateTime updatedDate;
 
 	public List<? extends GrantedAuthority> getGrantedAuthorities() {
-		return List.of(memberRole);
+		return memberRoleList;
 	}
 
 	// 최초 생성 시 updatedDate는 null로
@@ -77,10 +79,10 @@ public class Member {
 	}
 
 	public boolean isAdmin() {
-		return this.memberRole == MemberRole.ROLE_ADMIN;
+		return this.memberRoleList.contains(MemberRole.ROLE_ADMIN);
 	}
 
-	public void updatePassword(String encodedPassword) {
-		this.password = encodedPassword;
+	public boolean isGermany() {
+		return memberRoleList.contains(MemberRole.ROLE_GERMANY);
 	}
 }

--- a/src/main/java/com/leavebridge/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/leavebridge/member/repository/MemberQueryRepository.java
@@ -36,7 +36,7 @@ public class MemberQueryRepository {
 				Expressions.constant(targetMember.getId()),
 				Expressions.constant(targetMember.getName()),
 				Expressions.constant(15.0),
-				leaveAndHoliday.usedLeaveHours.sum()
+				leaveAndHoliday.usedLeaveDays.sum()
 			))
 			.from(leaveAndHoliday)
 			.where(
@@ -59,7 +59,7 @@ public class MemberQueryRepository {
 				leaveAndHoliday.starTime,
 				leaveAndHoliday.endDate,
 				leaveAndHoliday.endTime,
-				leaveAndHoliday.usedLeaveHours,
+				leaveAndHoliday.usedLeaveDays,
 				leaveAndHoliday.comment,
 				leaveAndHoliday.leaveType
 			))

--- a/src/main/java/com/leavebridge/member/service/MemberService.java
+++ b/src/main/java/com/leavebridge/member/service/MemberService.java
@@ -109,7 +109,7 @@ public class MemberService {
 
 		Member member = Member.builder()
 			.name(requestDto.memberName())
-			.memberRole(MemberRole.ROLE_MEMBER)
+			.memberRoleList(List.of(MemberRole.ROLE_MEMBER))
 			.loginId(requestDto.loginId())
 			.password(passwordEncoder.encode(requestDto.password()))
 			.build();

--- a/src/main/java/com/leavebridge/util/TimeRuleUtils.java
+++ b/src/main/java/com/leavebridge/util/TimeRuleUtils.java
@@ -1,0 +1,41 @@
+package com.leavebridge.util;
+
+import static com.leavebridge.calendar.entity.LeaveAndHoliday.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class TimeRuleUtils {
+
+	/**
+	 * 파견직 여부에 따라 근무시간, 오후연차 시작 시간, 근무 종료 시간을 반환합니다.
+	 */
+	public static LocalTime getAdjustStartTime(boolean isGermany) {
+		return isGermany ? WORK_START_TIME_FOR_GERMANY : WORK_START_TIME_FOR_MEMBER;
+	}
+
+	public static LocalTime getAdjustLunchBoundaryTime(boolean isGermany) {
+		return isGermany ? LUNCH_BOUNDARY_TIME_FOR_GERMANY : LUNCH_BOUNDARY_TIME_FOR_MEMBER;
+	}
+
+	public static LocalTime getAdjustEndTime(boolean isGermany) {
+		return isGermany ? WORK_END_TIME_FOR_GERMANY : WORK_END_TIME_FOR_MEMBER;
+	}
+
+	/**
+	 * 12:00~13:00 구간이 포함되는지
+	 */
+	public static boolean isLunchIncluded(LocalTime st, LocalTime en) {
+		return !st.isAfter(LUNCH_START)   //  st ≤ 12:00
+			   && !en.isBefore(LUNCH_END);   //  en ≥ 13:00
+	}
+
+	/**
+	 * 12:00 ~ 13:00 구간 전부만 포함한 일정인지 여부
+	 */
+	public static boolean isOnlyLunch(LocalDateTime start, LocalDateTime end) {
+		return !start.toLocalTime().isBefore(LUNCH_START)   // start ≥ 12:00
+			   && !end.toLocalTime().isAfter(LUNCH_END);       // end   ≤ 13:00
+	}
+
+}

--- a/src/main/resources/templates/calendar/home.html
+++ b/src/main/resources/templates/calendar/home.html
@@ -84,8 +84,8 @@
                             <option value="SUMMER_VACATION">여름휴가</option>
                             <option value="NON_DEDUCTIBLE">비차감 휴가(공가)</option>
                             <option value="MEETING">회의</option>
-                            <option sec:authorize="hasRole('ADMIN')" value="PUBLIC_HOLIDAY">공휴일</option>
-                            <option sec:authorize="hasRole('ADMIN')" value="ANNIVERSARY">기념일</option>
+                            <option sec:authorize="hasRole('ADMIN')" value="PUBLIC_HOLIDAY">공휴일(파견직 포함)</option>
+                            <option sec:authorize="hasRole('ADMIN')" value="ANNIVERSARY">기념일(파견직 미포함)</option>
                         </select>
                         <div class="form-text fw-bold">
                             한 번에 하나의 연차 타입만 등록 가능합니다. 다른 타입은 별도 등록해 주세요.
@@ -93,6 +93,7 @@
                         <div class="form-text fw-bold" sec:authorize="hasRole('ADMIN')" id="holidayNotice"
                              style="display: none;">
                             휴일 포함 체크시 기존에 등록된 연차들은 차감 연차 조정되거나 삭제됩니다.
+                            기념일의 경우 파견직에는 적용되지 않는 휴일입니다.
                         </div>
                     </div>
 
@@ -338,97 +339,49 @@
                 }
             }
 
-            // 3) leaveType 변경 시 UI 조정
             function onLeaveTypeChange() {
+                // 권한에 따른 근무 시간 상수 설정
+                const workStartTime     = isGermany ? '08:00' : '09:00';
+                const lunchBoundaryTime = isGermany ? '13:00' : '14:00';
+                const workEndTime       = isGermany ? '17:00' : '18:00';
+
                 const isHoliday = ['PUBLIC_HOLIDAY', 'ANNIVERSARY'].includes(leaveTypeEl.value);
                 const currentType = leaveTypeEl.value;
 
                 // holidayIncludeCheck 요소가 실제로 존재할 때만 동작
-                toggleHolidayIncludeUI(isHoliday)
-                // 0) 기본 리셋 (페어된 로직만 남김)
-                allDayCheck.disabled = false;
-                startTimeEl.required = false;
-                endTimeEl.required = false;
-                allDayCheck.checked = true;
-                timeGroup.style.display = 'none';
-                startDateEl.readOnly = false;
-                endDateEl.readOnly = false;
-                startTimeEl.readOnly = false;
-                endTimeEl.readOnly = false;
-                descriptionEl.required = false;
-                startTimeEl.removeAttribute('min');
-                startTimeEl.removeAttribute('max');
-                endTimeEl.removeAttribute('min');
-                endTimeEl.removeAttribute('max');
+                toggleHolidayIncludeUI(isHoliday);
 
-                // ✅ 반차·외출 3종은 “클릭한 날” 하루로 고정
-                const isHalfOrOuting = ['HALF_DAY_MORNING', 'HALF_DAY_AFTERNOON', 'OUTING']
-                    .includes(currentType);
+                // 기본 리셋
+                resetToDefaults();
+
+                // ✅ 반차·외출 3종은 "클릭한 날" 하루로 고정
+                const isHalfOrOuting = ['HALF_DAY_MORNING', 'HALF_DAY_AFTERNOON', 'OUTING'].includes(currentType);
 
                 if (isHalfOrOuting && anchorDate) {     // dateClick 으로 열린 경우에만
-                    startDateEl.value = anchorDate;
-                    endDateEl.value = anchorDate;
-                    startDateEl.readOnly = true;
-                    endDateEl.readOnly = true;
+                    setFixedDate(anchorDate);
                 }
 
-
-                // 1) 타입별 고유 설정
+                // 타입별 고유 설정
                 switch (currentType) {
-                    case '':
-                        allDayCheck.checked = true;
-                        startTimeEl.required = false;
-                        endTimeEl.required = false;
-                        return;
-
                     case 'FULL_DAY_LEAVE':
                     case 'SUMMER_VACATION':
-                        allDayCheck.checked = true;
-                        allDayCheck.disabled = true;
-                        startTimeEl.value = '00:00';
-                        endTimeEl.value = '23:59';
-                        startDateEl.readOnly = false;
-                        endDateEl.readOnly = false;
+                        setAllDayMode(true, '00:00', '23:59');
                         break;
 
                     case 'HALF_DAY_MORNING':
-                        allDayCheck.checked = false;
-                        allDayCheck.disabled = true;
-                        timeGroup.style.display = '';
-                        startTimeEl.value = '08:00';
-                        endTimeEl.value = '13:00';
-                        startDateEl.readOnly = true;
-                        endDateEl.readOnly = true;
-                        startTimeEl.readOnly = true;
-                        endTimeEl.readOnly = true;
+                        setTimeBasedMode(workStartTime, lunchBoundaryTime, true);
                         return;  // 범위 세팅도 필요 없으니 리턴
 
                     case 'HALF_DAY_AFTERNOON':
-                        allDayCheck.checked = false;
-                        allDayCheck.disabled = true;
-                        timeGroup.style.display = '';
-                        startTimeEl.value = '13:00';
-                        endTimeEl.value = '17:00';
-                        startDateEl.readOnly = true;
-                        endDateEl.readOnly = true;
-                        startTimeEl.readOnly = true;
-                        endTimeEl.readOnly = true;
+                        setTimeBasedMode(lunchBoundaryTime, workEndTime, true);
                         return;
 
                     case 'OUTING':
-                        allDayCheck.checked = false;
-                        allDayCheck.disabled = true;
-                        timeGroup.style.display = '';
-                        startDateEl.readOnly = true;
-                        endDateEl.readOnly = true;
-                        startTimeEl.min = '08:00';
-                        startTimeEl.max = '17:00';
-                        endTimeEl.min = '08:00';
-                        endTimeEl.max = '17:00';
+                        setTimeBasedMode(null, null, false, workStartTime, workEndTime);
                         break;
 
                     case 'NON_DEDUCTIBLE':
-                        descriptionEl.required = true
+                        descriptionEl.required = true;
                         break;
 
                     case 'MEETING':
@@ -437,7 +390,60 @@
                     default:
                         break;
                 }
+            }
 
+            function resetToDefaults() {
+                allDayCheck.disabled = false;
+                allDayCheck.checked = true;
+                startTimeEl.required = false;
+                endTimeEl.required = false;
+                timeGroup.style.display = 'none';
+                startDateEl.readOnly = false;
+                endDateEl.readOnly = false;
+                startTimeEl.readOnly = false;
+                endTimeEl.readOnly = false;
+                descriptionEl.required = false;
+
+                // 시간 제한 초기화
+                startTimeEl.min = '';
+                startTimeEl.max = '';
+                endTimeEl.min = '';
+                endTimeEl.max = '';
+            }
+
+            function setFixedDate(date) {
+                startDateEl.value = date;
+                endDateEl.value = date;
+                startDateEl.readOnly = true;
+                endDateEl.readOnly = true;
+            }
+
+            function setAllDayMode(disabled, startTime, endTime) {
+                allDayCheck.checked = true;
+                allDayCheck.disabled = disabled;
+                if (startTime) startTimeEl.value = startTime;
+                if (endTime) endTimeEl.value = endTime;
+            }
+
+            function setTimeBasedMode(startTime, endTime, readOnlyTime, minTime, maxTime) {
+                allDayCheck.checked = false;
+                allDayCheck.disabled = true;
+                timeGroup.style.display = '';
+
+                if (startTime) startTimeEl.value = startTime;
+                if (endTime) endTimeEl.value = endTime;
+
+                if (readOnlyTime) {
+                    startTimeEl.readOnly = true;
+                    endTimeEl.readOnly = true;
+                }
+
+                if (minTime && maxTime) {
+                    startTimeEl.min = minTime;
+                    startTimeEl.max = maxTime;
+                    endTimeEl.min = minTime;
+                    endTimeEl.max = maxTime;
+                }
             }
 
             leaveTypeEl.addEventListener('change', onLeaveTypeChange);
@@ -716,8 +722,10 @@
                     currentIsHoliday = false;
 
                     // (휴일 UI 숨기기)
-                    holidayIncludeGroup.style.display = 'none';
-                    holidayNotice.style.display = 'none';
+                    if(holidayIncludeGroup) {
+                        holidayIncludeGroup.style.display = 'none';
+                        holidayNotice.style.display = 'none';
+                    }
 
                     // UI 토글 함수를 한 번 더 호출
                     onLeaveTypeChange();

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -2,6 +2,7 @@
 <html lang="ko"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 <head>
+    <link rel="icon" href="data:;base64,=">
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- CSRF 메타태그를 실제 값으로 렌더링 -->
@@ -56,6 +57,7 @@
     <script th:inline="javascript">
         /*<![CDATA[*/
         window.isAuthenticated = /*[[${isAuthenticated}]]*/ false;
+        window.isGermany = /*[[${isGermany}]]*/ false;
         /*]]>*/
     </script>
 


### PR DESCRIPTION
## 구현 사항 요약
- 월간 조회 로직 개선
  - 월 첫날만 보던 기존 쿼리를 직전 달 말일까지 확장해 6/30 ~ 7/2 같은 일정도 포함
- 공통 Validator 컴포넌트 도입
  - 요청 DTO 기본 검증 강화(Null/범위 등)
  - HTML 조작하여 강제성 풀어서 요청 보내는 꼼수 등 방지
- 파견직/일반직에 따른 연차 시간 조정
  - 근무시간 다름에 따른 연차 시작 시간 조정 (8시 vs 9시 / 13시 vs 14시 등)
  - 파견직은 기념일 휴일의 영향받지 않도록 수정 (관리자가 다른 회사 파견 간 직원의 대체 휴무 지정하기가 불가능하기 때문)
- `favicon` 자동 요청 차단
- Member Role List로 가질 수 있게 엔티티 컬럼 수정
  - DB 저장, 조회 시 자동으로 List <-> String 처리를 위한 Converter 추가

## 목표 구현 사항
- [x] DB 도입
- [x] 테이블 및 Entity 설계
  - [x] `LEAVE_AND_HOLIDAYS` : 공휴일 + 등록된 연차 목록 저장 + **해당 일정이 얼마만큼의 연차를 소진한건지 double 컬럼 추가**
  - [x] `MEMBER` : 사용자 정보 저장
- [x] Spring Security 도입
  - [x] form_login 도입

- [x] CRUD 기능 더미로 만들어둔 것 로직 전반적 수정
  - [x] 공휴일 조회 로직 제거 & 스케줄러로 불러와서 DB 저장

  - [x] 일정 목록 조회 로직 구글 캘린더에서 조회하는 방식이 아닌 DB에서 가져오도록 수정
    - [x] 매일 00시 캘린더 API 호출하여 DB 최신화 초안(서비스 이용 회원은 항상 최신화 이나 비회원들은 00시 최신화)

  - [x] 일정 상세 조회 (구글 캘린더 API 호출 -> DB 조회)
    - [x] 수정된 스케줄러 등에서 구글 캘린더 일정 가져올 때, 일정에 대한 description 정보도 같이 저장 등 수정 필요
    - [x] 프론트에서 모달 창으로 일정 상세 표시

  - [x] 일정 등록 (구글 캘린더 API 호출 -> 구글 캘린더 API 호출 + DB 저장)
    - [x] Calendar Event Id가 필요하여 API 먼저 호출하고 DB 저장, 각 단계에서 예외나면 적절히 처리
    - [x] 프론트에서 API 호출
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신

  - [x] 일정 수정
    - [x] DB 수정
    - [x] 구글 캘린더 수정 API 호출
    - [x] 프론트
      - [x] 등록 모달을 수정 모달도 같이 사용하도록 수정
        - API와 검증은 동일하게
      - [x]  Calendar 일정 다시 DB에서 받아오고 갱신
    - [x] (추가) 휴일 일정 변경, 휴일 여부 변경 등 삭제하고 다시 생성하도록 입구컷
    - [x] (추가) 일정 수정 시 수정하려는 일정이 휴일 등으로 연차 사용 시간이 0시간이라면 수정 튕겨내도록 수정
      - 사실 이미 삭제되었을 것

  - [x] 일정 삭제
    - [x] DB 삭제
    - [x] 구글 캘린더 삭제 API 호출
    - [x] 프론트
      - [x] 삭제 확인 모달 추가
      - [x] Calendar 일정 다시 DB에서 받아오고 갱신
    - [x] (추가) 휴일 삭제할 경우 해당 기간에 속한 연차들 다시 불러와서 연차 기간 다시 계산하도록

- [x] 로그인 페이지

- [x] 연차 사용 현황 페이지

- [x] 비밀번호 변경 페이지
- [x] 비밀번호 변경 API

- [x] 토스트 메시지 (예외 메시지, 성공 메시지)

- [x] 일정 상세에서 본인이 작성한 일정인 경우만 수정, 삭제 버튼 노출

- [x] API 리팩토링
  - [x] Dto 값 검증 (하루 연차인데 시간은 반차던가 필수값 미입력 등 적절하지 않은 입력 검증 필요)
    - 그냥 LeaveType에 따라 값 강제로 변경하도록 수정
  - [x] 본인이 작성한 일정만 수정, 삭제 가능하도록
  - [x] 예외 처리 통일하여 Global Exception Handler 도입하여 수정
  - [x] 일정 등록, 수정 시 사용한 연차 계산하여 저장
  - [x] 연차 현황 조회 시 단순히 사용 일정 더하기, 사용 일정도 그대로 받아오도록 수정 (간소화)
  - [x] (추가) 파견직, 일반 직원 모두 사용할 수 있도록 수정
    - [x] 파견직의 경우 관리자가 등록한 "기념일 + 휴일" 영향 받지 않도록 수정
    - [x] 구글 캘린더 연동은 파견직만 하도록 수정
    - [x] 연차 시간대 수정 (연차, 오전 반차, 오후 반차, 외출 등)

- [x] Spring Security User Custom 등록하여 Member 엔티티 꺼내 바로 사용할 수 있도록

- [x] 개인별 연차 사용 현황 조회 API
  - 테이블 설계 없이 기능 구현