### PR TITLE
refactor : 헬스체크 API 추가 + 엔티티 생성일  기본값 @Createdate 어노테이션 있으니 now() 메서드 삭제

### DIFF
--- a/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
+++ b/src/main/java/com/leavebridge/calendar/entity/LeaveAndHoliday.java
@@ -94,7 +94,7 @@ public class LeaveAndHoliday {
 
 	@Column(name = "CREATED_DATE")
 	@CreatedDate
-	private LocalDateTime createdDate = LocalDateTime.now();
+	private LocalDateTime createdDate;
 
 	@Column(name = "UPDATED_DATE")
 	@LastModifiedDate

--- a/src/main/java/com/leavebridge/config/SecurityConfig.java
+++ b/src/main/java/com/leavebridge/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
 				// .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
 				.requestMatchers("/", "/members/login", "/css/**", "/js/**").permitAll()
 				.requestMatchers("/api/*/calendar/events/*/*").permitAll() // 일정 조회
+				.requestMatchers("/health").permitAll() // 헬스 체크 열어두기
 				.requestMatchers("/members/login").permitAll() // 메인 페이지 누구나 가능
 				.requestMatchers("/members/signup", "/api/*/members/signup").permitAll() // 회원가입 누구나 가능
 				.requestMatchers("/usage").permitAll() // 연차 사용 현황 누구나 가능

--- a/src/main/java/com/leavebridge/home/HomeController.java
+++ b/src/main/java/com/leavebridge/home/HomeController.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.leavebridge.member.entitiy.MemberRole;
 
@@ -23,5 +24,11 @@ public class HomeController {
 
 		model.addAttribute("isGermany", isGermany);
 		return "calendar/home";
+	}
+
+	@GetMapping("/health")
+	@ResponseBody
+	public String health() {
+		return "ok";
 	}
 }


### PR DESCRIPTION
## 구현 사항 요약
- ELB Health Check용 API 추가 
  - 홈 화면인 `/` 경로 그대로 사용해도 되지만 인증여부 검증하는 로직이 포함되어 있어 빠른 헬스 체크를 위한 API 신설
- `@CreateDate` 어노테이션 사용으로 인해 엔티티 속성에 기본값 지정 로직 삭제

## 목표 구현 사항
- [x] EC2 + RDS + ELB 이용 배포
  - [x] Health Check API 추가
- [x] HTTPS 적용
- [ ] Google Calendar OAuth 설정하여 EC2 환경에서도 캘린더 조작 가능하도록