### PR TITLE
refactor : Member 엔티티에 JPA Auditing 적용하여 생성일 DB 저장되도록 수정

### DIFF
--- a/src/main/java/com/leavebridge/member/entitiy/Member.java
+++ b/src/main/java/com/leavebridge/member/entitiy/Member.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.core.GrantedAuthority;
 
 import com.leavebridge.calendar.entity.LeaveAndHoliday;
@@ -14,6 +15,7 @@ import com.leavebridge.member.converter.MemberRoleListConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -33,6 +35,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "MEMBER")
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 구현 사항 요약
- Member 엔티티에 JPA Auditing 적용하여 생성일 DB 저장되도록 수정
