### PR TITLE
prod 환경에서 JSCH 사용하여 SSH 터널링으로 RDS 접속하도록 설정 (RDS public Ip 해제)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,9 @@ dependencies {
 
     // Validator
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // JSch : SSH tunneling 자동 열기
+    implementation("com.jcraft:jsch:0.1.55")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leavebridge/config/SshTunnelConfig.java
+++ b/src/main/java/com/leavebridge/config/SshTunnelConfig.java
@@ -1,0 +1,44 @@
+package com.leavebridge.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+@Profile("prod") // 배포 환경일때만 적용
+@Configuration
+public class SshTunnelConfig {
+	@Value("${ssh.host}")        private String sshHost;
+	@Value("${ssh.port}")        private int sshPort;
+	@Value("${ssh.user}")        private String sshUser;
+	@Value("${ssh.privateKey}")  private String sshKey;
+	@Value("${ssh.remoteHost}")  private String remoteHost;
+	@Value("${ssh.remotePort}")  private int remotePort;
+	@Value("${ssh.localPort}")   private int localPort;
+
+	private Session session;
+
+	@PostConstruct  // 의존성 주입 완료된 직후 초기화 콜백 메서드
+	public void initSshTunnel() throws Exception {
+		JSch jsch = new JSch();
+		jsch.addIdentity(sshKey);                      // 키 파일 등록
+		session = jsch.getSession(sshUser, sshHost, sshPort);  // 세션 객체 생성 (사용자명, 호스트, 포트 정보)
+		session.setConfig("StrictHostKeyChecking", "no");  // 호스트키 검사(no 하면 자동으로 호스트키 신뢰)
+		session.connect();                             // SSH 접속 수립 (TCP 연결, SSH 핸드쉐이크 및 인증)
+		session.setPortForwardingL(localPort, remoteHost, remotePort); // localhost:localPort -> remoteHost:remotePort
+		System.out.printf("SSH 터널 수립: localhost:%d → %s:%d%n",
+			localPort, remoteHost, remotePort);
+	}
+
+	@PreDestroy // 애플리케이션 컨텍스트 종료 or 빈 제거 직전 호출되어 리소스 해체나 정리
+	public void closeSshTunnel() {
+		if (session != null && session.isConnected()) {
+			session.disconnect();                      // 애플리케이션 종료 시 터널 해제
+		}
+	}
+}

--- a/src/main/resources/application-prod.yml.template
+++ b/src/main/resources/application-prod.yml.template
@@ -1,0 +1,24 @@
+server:
+  port: 8080
+
+ssh:
+  host: {public ip}        # Jump Host 또는 EC2 퍼블릭 IP
+  port: 22                          # SSH 기본 포트
+  user: {user_name}               # SSH 로그인 사용자명
+  privateKey: {../*-key-pair.pem} # SSH 프라이빗 키 파일 경로
+  localPort: 54320                  # 로컬 포워딩할 포트
+  remoteHost: {...} # RDS 엔드포인트
+  remotePort: 3306                  # RDS 포트
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:${ssh.localPort}/{db_name}
+    username: {rds_username}
+    password: {rds_password}
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+# 오버라이드 되서 실제 prod 프로필에선 실제 구글 캘린더 이용됨
+google:
+  calendar-id : {google_calendar_Id_in_prod}


### PR DESCRIPTION
## 구현 사항 요약
- prod 환경에서 JSCH 사용하여 SSH 터널링으로 RDS 접속하도록 설정 (RDS public Ip 해제)

## 목표 구현 사항
- ELB 뺴고 Nginx Proxy Manager 이용하여 HTTPS 이용하기