### PR TITLE
SSH 터널링으로 RDS 접속 시 인증 안되는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,8 @@ dependencies {
     // Validator
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    // JSch : SSH tunneling 자동 열기
-    implementation("com.jcraft:jsch:0.1.55")
+    // apache.sshd
+    implementation 'org.apache.sshd:sshd-core:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leavebridge/config/DataSourceConfig.java
+++ b/src/main/java/com/leavebridge/config/DataSourceConfig.java
@@ -1,0 +1,38 @@
+package com.leavebridge.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("prod")
+public class DataSourceConfig {
+
+	@Value("${spring.datasource.username}")
+	private String dbUser;
+
+	@Value("${spring.datasource.password}")
+	private String dbPass;
+
+	@Value("${spring.datasource.driver-class-name}")
+	private String dbDriver;
+
+	@Value("${spring.datasource.url}")
+	private String url;
+
+	@Bean
+	@DependsOn("sshTunnelConfig")  // ❶ 반드시 SSH 터널 먼저 초기화
+	public DataSource dataSource() {
+		return DataSourceBuilder.create()                   // Spring Boot 기본 Builder 사용
+			.driverClassName(dbDriver)
+			.url(url)
+			.username(dbUser)
+			.password(dbPass)
+			.build();
+	}
+}

--- a/src/main/java/com/leavebridge/config/SshTunnelConfig.java
+++ b/src/main/java/com/leavebridge/config/SshTunnelConfig.java
@@ -1,44 +1,79 @@
 package com.leavebridge.config;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyPair;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.config.keys.FilePasswordProvider;
+import org.apache.sshd.common.config.keys.loader.KeyPairResourceLoader;
+import org.apache.sshd.common.util.net.SshdSocketAddress;
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.Session;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
-@Profile("prod") // 배포 환경일때만 적용
-@Configuration
+@Configuration("sshTunnelConfig")
+@Profile("prod")
 public class SshTunnelConfig {
+
 	@Value("${ssh.host}")        private String sshHost;
 	@Value("${ssh.port}")        private int sshPort;
 	@Value("${ssh.user}")        private String sshUser;
 	@Value("${ssh.privateKey}")  private String sshKey;
+
 	@Value("${ssh.remoteHost}")  private String remoteHost;
 	@Value("${ssh.remotePort}")  private int remotePort;
 	@Value("${ssh.localPort}")   private int localPort;
 
-	private Session session;
+	private ClientSession session;
 
-	@PostConstruct  // 의존성 주입 완료된 직후 초기화 콜백 메서드
+	@PostConstruct
 	public void initSshTunnel() throws Exception {
-		JSch jsch = new JSch();
-		jsch.addIdentity(sshKey);                      // 키 파일 등록
-		session = jsch.getSession(sshUser, sshHost, sshPort);  // 세션 객체 생성 (사용자명, 호스트, 포트 정보)
-		session.setConfig("StrictHostKeyChecking", "no");  // 호스트키 검사(no 하면 자동으로 호스트키 신뢰)
-		session.connect();                             // SSH 접속 수립 (TCP 연결, SSH 핸드쉐이크 및 인증)
-		session.setPortForwardingL(localPort, remoteHost, remotePort); // localhost:localPort -> remoteHost:remotePort
-		System.out.printf("SSH 터널 수립: localhost:%d → %s:%d%n",
-			localPort, remoteHost, remotePort);
+		SshClient client = SshClient.setUpDefaultClient();  // 기본 클라이언트 생성
+		client.start();                                      // 클라이언트 시작
+
+		// PEM 키 파싱용 로더 생성
+		KeyPairResourceLoader loader = SecurityUtils.getKeyPairResourceParser();
+		Path keyPath = Paths.get(sshKey);
+
+		// loader.loadKeyPairs : PEM, OpenSSH, RFC4716 등 다양한 키 포맷을 모두 파싱할 수 있도록 설계
+		// 하나의 파일에 여러 키 쌍이 포함되어 있거나 서로 다른 알고리즘의 키 연속 저장된 경우 있어 모든 키 순회하기 위한 Collection
+		// 이후 반환 컬렉션 중 필요한 키 하나를 선택하여 공개키 인증에 사용
+		/**
+		 * 첫번째 인자 : 선택적 세션 컨텍스트 또는 리소스 식별자
+		   - 키 파싱 시 추가 정보(호스트 식별 등) 제공
+		   - 파일 기반 파싱 null로 기본 컨텍스트 사용
+		 * 두번째 인자 : 실제 키 파일 경로, 이 객체가 가리키는 파일을 읽어 내부 하나 이상의 개인키, 공개키 쌍 파싱
+		 * 세번째 인자 : 패스프레이즈 공급자, 암호화된 키 파일의 복호화를 위해 필요한 패스프레이즈
+		   - 패스 프레이즈 없음(빈문자), **암호화 되지 않은 키를 다룰 때 사용**
+		   - 만일 키 파일이 `passphrase-protected` 상태라면 실제 패스프레이즈를 입력해야 함.
+		 */
+		Collection<KeyPair> keys = loader.loadKeyPairs(null, keyPath, FilePasswordProvider.of(""));
+
+		// SSH 세션 생성 및 연결
+		session = client.connect(sshUser, sshHost, sshPort)
+			.verify(10, TimeUnit.SECONDS)
+			.getSession();
+		// 공개키 인증
+		session.addPublicKeyIdentity(keys.iterator().next());
+		session.auth().verify(10, TimeUnit.SECONDS);
+
+		SshdSocketAddress localAddr  = new SshdSocketAddress("localhost", localPort);
+		SshdSocketAddress remoteAddr = new SshdSocketAddress(remoteHost, remotePort);
+		session.startLocalPortForwarding(localAddr, remoteAddr);  // 포워딩 설정
 	}
 
-	@PreDestroy // 애플리케이션 컨텍스트 종료 or 빈 제거 직전 호출되어 리소스 해체나 정리
-	public void closeSshTunnel() {
-		if (session != null && session.isConnected()) {
-			session.disconnect();                      // 애플리케이션 종료 시 터널 해제
+	@PreDestroy
+	public void closeSshTunnel() throws Exception {
+		if (session != null && session.isOpen()) {
+			session.close();  // 터널 해제
 		}
 	}
 }


### PR DESCRIPTION
## 구현 사항 요약
- 라이브러리 변경
  - 변경 : `jsch` -> `sshd`
  - 사유 : 인증서를 계속 읽지 못하기에 변경
- prod 프로필일때 DataSource 수동 빈 등록
  - 사유 : ssh tunneling 이전에 DataSource를 읽으려고 해서 계속 예외발생 -> 명시적으로 터널링 이후에 빈 등록 하라고 순서 지정

## 목표 구현 사항
- ELB 제거, Nginx Proxy Manager(Let's Encrypt) 이용한 HTTPS 적용