### PR TITLE
feat : slack 메시지 연동 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ dependencies {
 
     // apache.sshd
     implementation 'org.apache.sshd:sshd-core:2.7.0'
+
+    // slack
+    implementation("com.slack.api:slack-api-client:1.45.3")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leavebridge/slack/client/SlackApiClient.java
+++ b/src/main/java/com/leavebridge/slack/client/SlackApiClient.java
@@ -1,0 +1,55 @@
+package com.leavebridge.slack.client;
+
+import java.io.IOException;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class SlackApiClient {
+
+	@Value("${slack.channel-id}")
+	private String channelId;
+
+	private final MethodsClient methods;
+
+	public SlackApiClient(@Value("${slack.bot-token}") String token) {
+		SlackConfig config = new SlackConfig();
+		config.setPrettyResponseLoggingEnabled(true);  // Json 들여쓰기 등 적용하여 로깅 남김
+		Slack slack = Slack.getInstance(config);
+		this.methods = slack.methods(token);
+	}
+
+	@Retryable(
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 2000, multiplier = 2.0),
+		retryFor = { IOException.class, com.slack.api.methods.SlackApiException.class }
+	)
+	public void sendMessage(String text) throws SlackApiException, IOException {
+		ChatPostMessageResponse chatPostMessageResponse = methods.chatPostMessage(r -> r
+			.channel(channelId)
+			.text(text)
+		);
+		if(!chatPostMessageResponse.isOk()){
+			throw new IllegalStateException("Slack error: " + chatPostMessageResponse.getError());
+		}
+	}
+
+	@Recover
+	public void recover(Exception e, String channelId, String text) {
+		// 3회 모두 실패시 마지막으로 여기로 옴 (로그/알림 등)
+		log.error("Slack send failed after retries. channel={}, text={}", channelId, text, e);
+	}
+}

--- a/src/main/java/com/leavebridge/slack/scheduler/SlackScheduler.java
+++ b/src/main/java/com/leavebridge/slack/scheduler/SlackScheduler.java
@@ -1,0 +1,99 @@
+package com.leavebridge.slack.scheduler;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.leavebridge.slack.client.SlackApiClient;
+import com.leavebridge.slack.service.BusinessDayService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@EnableScheduling
+@Component
+@RequiredArgsConstructor
+public class SlackScheduler {
+
+	private final SlackApiClient slackApiClient;
+	private final BusinessDayService businessDayService;
+
+	// 중복 전송 방지 (동일 인스턴스)
+	private final AtomicBoolean sentToday = new AtomicBoolean(false);
+
+	private static final DateTimeFormatter KOR = DateTimeFormatter.ofPattern("yyyy년 M월 d일(E)", Locale.KOREAN);
+
+	// 실제 한 번 실행 로직 (여러 스케줄에서 공용 호출)
+	public void trySendOnce() {
+		LocalDate today = LocalDate.now();
+
+		if (sentToday.get()) {
+			log.info("이미 오늘 보냄. skip");
+			return;
+		}
+
+		// 1) 오늘이 주말/공휴일이면 종료
+		if (!businessDayService.isBusinessDay(today)) {
+			log.info("Skip: today {} is not a business day", today);
+			return;
+		}
+
+		// 2) 어제부터 거슬러 올라가며 마지막 근무일 찾기
+		LocalDate target = businessDayService.findLastBusinessDayBefore(today);
+
+		// (보내는 문구)
+		String text = """
+			🪖 *독일광부 작업반장 알림* ⛏️
+			좋은 아침입니다! 🙌
+			*%s*에 하신 작업을 *이 메시지에 스레드 댓글*로 간단히 남겨주세요.
+			안전모 단단히! 작은 전진이 큰 성과를 만듭니다. 🤝
+			""".formatted(target.format(KOR));
+
+		try {
+			// 전송 시도 (3회 재시도 내장)
+			slackApiClient.sendMessage(text);
+
+			// ✅ 성공한 경우에만 true로
+			sentToday.set(true);
+		} catch (Exception e) {
+			// 실패: sentToday 를 건드리지 않음 → 백업 스케줄/수동 재시도 기회 보장
+			log.warn("Slack 메시지 전송 실패 cause={}", e.toString());
+		}
+	}
+
+	/**
+	 * 매일 08:00 (Asia/Seoul) 1차 시도
+	 */
+	// 테스트용 1분마다
+	// @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+	public void run0800() {
+		trySendOnce();
+	}
+
+	/**
+	 * (선택) 2차 시도: 08:10
+	 */
+	@Scheduled(cron = "0 10 8 * * *", zone = "Asia/Seoul")
+	public void run0810() {
+		trySendOnce();
+	}
+
+	/**
+	 * 자정에 플래그 초기화
+	 */
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	@Retryable(maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 2.0))
+	public void resetFlag() {
+		sentToday.set(false);
+	}
+
+}

--- a/src/main/java/com/leavebridge/slack/service/BusinessDayService.java
+++ b/src/main/java/com/leavebridge/slack/service/BusinessDayService.java
@@ -1,0 +1,41 @@
+package com.leavebridge.slack.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import com.leavebridge.calendar.enums.LeaveType;
+import com.leavebridge.calendar.repository.LeaveAndHolidayRepository;
+
+@Service
+@RequiredArgsConstructor
+public class BusinessDayService {
+
+	private final LeaveAndHolidayRepository leaveAndHolidayRepository;
+
+	public boolean isWeekend(LocalDate date) {
+		DayOfWeek w = date.getDayOfWeek();
+		return w == DayOfWeek.SATURDAY || w == DayOfWeek.SUNDAY;
+	}
+
+	public boolean isHoliday(LocalDate date) {
+		// 오늘 날짜로 된 휴일이 존재하는지 여부(파견직은 기념일 휴일에 영향 안받기 때문에 기념일 제외)
+		return leaveAndHolidayRepository
+			.existsByStartDateLessThanEqualAndEndDateGreaterThanEqualAndIsHolidayTrueAndIsAllDayTrueAndLeaveTypeNot(
+				date, date, LeaveType.ANNIVERSARY);
+	}
+
+	public boolean isBusinessDay(LocalDate d) {
+		return !isWeekend(d) && !isHoliday(d);
+	}
+
+	/** today 이전에서 마지막 근무일을 찾음 (어제→전날→... 반복) */
+	public LocalDate findLastBusinessDayBefore(LocalDate today) {
+		LocalDate cursor = today.minusDays(1);
+		while (!isBusinessDay(cursor)) {
+			cursor = cursor.minusDays(1);
+		}
+		return cursor;
+	}
+}

--- a/src/main/resources/application-prod.yml.template222
+++ b/src/main/resources/application-prod.yml.template222
@@ -13,3 +13,7 @@ spring:
 # 오버라이드 되서 실제 prod 프로필에선 실제 구글 캘린더 이용됨
 # google:
   # calendar-id : {google_calendar_Id_in_prod}
+
+slack:
+  bot-token: {bot_token}
+  channel-id: {채널 Id}

--- a/src/main/resources/application-secret.yml.template
+++ b/src/main/resources/application-secret.yml.template
@@ -2,3 +2,7 @@ google:
   calendar-id: "personal calendar Id"
 data:
   secret-key : "personal Open API Key"
+
+slack:
+   bot-token: {bot_token}
+   channel-id: {채널 Id}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -82,6 +82,13 @@
         <discardingThreshold>0</discardingThreshold>
     </appender>
 
+    <!-- slack log 끄기 -->
+    <Configuration>
+        <Loggers>
+            <Logger name="com.slack.api" level="off" additivity="false"/>
+        </Loggers>
+    </Configuration>
+
     <!-- 루트 로거 -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
## 구현 사항 요약
- Slack API를 통해 채팅방에 메시지를 전송합니다.
  - 주말, 공휴일의 경우 메시지를 전송하지 않습니다.
  - 돌아오는 월요일, 주말 뭐했는지가 아닌 근무일에 무슨일을 했는지 물어봅니다.